### PR TITLE
Fix TypeScript prototypes

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,12 +1,22 @@
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 declare global {
-	namespace App {
-		// interface Error {}
-		// interface Locals {}
-		// interface PageData {}
-		// interface Platform {}
-	}
+        namespace App {
+                // interface Error {}
+                // interface Locals {}
+                // interface PageData {}
+                // interface Platform {}
+        }
+
+        interface Array<T> {
+                shuffle(): T[]
+        }
+
+        interface String {
+                spintax(): string
+                bold(): string
+                underline(): string
+        }
 }
 
 export {};


### PR DESCRIPTION
## Summary
- add missing global type definitions for custom prototype helpers

## Testing
- `npm run validate` *(fails: svelte-check found 32 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6846bced9258832fbf8897ff1d279a37