### PR TITLE
Fix PWA build error

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,13 @@ import { defineConfig } from 'vite';
 import { SvelteKitPWA } from '@vite-pwa/sveltekit'
 
 export default defineConfig({
-	plugins: [sveltekit(), SvelteKitPWA({
-		manifestFilename: 'static/manifest.json',
-	})],
+        plugins: [
+                sveltekit(),
+                SvelteKitPWA({
+                        manifestFilename: 'static/manifest.json',
+                        workbox: {
+                                maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
+                        },
+                }),
+        ],
 });


### PR DESCRIPTION
## Summary
- set `maximumFileSizeToCacheInBytes` to allow precaching larger assets

## Testing
- `npm run build:app`

------
https://chatgpt.com/codex/tasks/task_e_6846bf724f74832f94cade62de0427ae