### PR TITLE
Allow previewing future blog posts

### DIFF
--- a/src/lib/utils/BlogUtilities.ts
+++ b/src/lib/utils/BlogUtilities.ts
@@ -2,7 +2,7 @@ import BlogPost from "$lib/components/BlogPost.svelte";
 import { Locales } from "$lib/types/Locales";
 
 export class BlogUtilities {
-    public static getPosts(locale: Locales) {
+    public static getPosts(locale: Locales, includeFuture: boolean = false) {
         let posts;
         switch (locale) {
             case Locales.en:
@@ -23,14 +23,21 @@ export class BlogUtilities {
             return null;
         });
 
+        const now = new Date();
+
+        // Remove posts dated in the future unless previewing
+        if (!includeFuture) {
+            posts = posts.filter((post) => post && post.date <= now);
+        }
+
         // sort posts by date
         posts.sort((a, b) => a.date.getTime() - b.date.getTime()).reverse();
 
         return posts;
     }
 
-    public static getPostBySlug(locale: Locales, slug: string) {
-        let posts: BlogPost[] = this.getPosts(locale);
+    public static getPostBySlug(locale: Locales, slug: string, includeFuture: boolean = false) {
+        let posts: BlogPost[] = this.getPosts(locale, includeFuture);
         return posts.find(post => post.seoTag === slug);
     }
 }

--- a/src/routes/(blog)/blog/[locale]/+page.svelte
+++ b/src/routes/(blog)/blog/[locale]/+page.svelte
@@ -6,7 +6,8 @@
     import { BlogUtilities } from "$lib/utils/BlogUtilities";
 
     const locale = getLocaleFromString($page.params.locale);
-    const posts: PostData[] = BlogUtilities.getPosts(locale);
+    const preview = $page.url.searchParams.has('preview');
+    const posts: PostData[] = BlogUtilities.getPosts(locale, preview);
 </script>
 
 <svelte:head>

--- a/src/routes/(blog)/blog/[locale]/[seoTag]/+page.svelte
+++ b/src/routes/(blog)/blog/[locale]/[seoTag]/+page.svelte
@@ -6,8 +6,9 @@
 
     const locale = getLocaleFromString($page.params.locale);
     const seoTag = $page.params.seoTag;
+    const preview = $page.url.searchParams.has('preview');
 
-    const post = BlogUtilities.getPostBySlug(locale, seoTag);
+    const post = BlogUtilities.getPostBySlug(locale, seoTag, preview);
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary
- add `includeFuture` flag to `BlogUtilities.getPosts` and `getPostBySlug`
- use `preview` query parameter so authors can view future posts

## Testing
- `npm run validate` *(fails: `svelte-check` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c2dab828832f9529005421ee06df