### PR TITLE
Allow previewing future blog posts

### DIFF
--- a/src/lib/utils/BlogUtilities.ts
+++ b/src/lib/utils/BlogUtilities.ts
@@ -2,7 +2,7 @@ import BlogPost from "$lib/components/BlogPost.svelte";
 import { Locales } from "$lib/types/Locales";
 
 export class BlogUtilities {
-    public static getPosts(locale: Locales) {
+    public static getPosts(locale: Locales, includeFuture: boolean = false) {
         let posts;
         switch (locale) {
             case Locales.en:
@@ -23,14 +23,21 @@ export class BlogUtilities {
             return null;
         });
 
+        const now = new Date();
+
+        // Remove posts dated in the future unless previewing
+        if (!includeFuture) {
+            posts = posts.filter((post) => post && post.date <= now);
+        }
+
         // sort posts by date
         posts.sort((a, b) => a.date.getTime() - b.date.getTime()).reverse();
 
         return posts;
     }
 
-    public static getPostBySlug(locale: Locales, slug: string) {
-        let posts: BlogPost[] = this.getPosts(locale);
+    public static getPostBySlug(locale: Locales, slug: string, includeFuture: boolean = false) {
+        let posts: BlogPost[] = this.getPosts(locale, includeFuture);
         return posts.find(post => post.seoTag === slug);
     }
 }

--- a/src/routes/(blog)/blog/[locale]/+page.svelte
+++ b/src/routes/(blog)/blog/[locale]/+page.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
     import { page } from "$app/stores";
+    import { browser } from "$app/environment";
     import { _ } from "$lib/locales";
     import { getLocaleFromString, Locales } from "$lib/types/Locales";
     import type { PostData } from "$lib/types/PostData";
     import { BlogUtilities } from "$lib/utils/BlogUtilities";
 
     const locale = getLocaleFromString($page.params.locale);
-    const posts: PostData[] = BlogUtilities.getPosts(locale);
+    let preview = false;
+    let posts: PostData[] = BlogUtilities.getPosts(locale);
+
+    $: preview = browser && $page.url.searchParams.has('preview');
+    $: posts = BlogUtilities.getPosts(locale, preview);
 </script>
 
 <svelte:head>

--- a/src/routes/(blog)/blog/[locale]/[seoTag]/+page.svelte
+++ b/src/routes/(blog)/blog/[locale]/[seoTag]/+page.svelte
@@ -1,13 +1,18 @@
 <script lang="ts">
     import { BlogUtilities } from "$lib/utils/BlogUtilities";
     import { page } from '$app/stores';
+    import { browser } from "$app/environment";
     import { getLocaleFromString } from "$lib/types/Locales";
     import BlogPost from "$lib/components/BlogPost.svelte";
 
     const locale = getLocaleFromString($page.params.locale);
     const seoTag = $page.params.seoTag;
 
-    const post = BlogUtilities.getPostBySlug(locale, seoTag);
+    let preview = false;
+    let post = BlogUtilities.getPostBySlug(locale, seoTag);
+
+    $: preview = browser && $page.url.searchParams.has('preview');
+    $: post = BlogUtilities.getPostBySlug(locale, seoTag, preview);
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary
- add preview toggle only in browser to avoid prerender errors
- use preview query parameter to load future posts when browsing
- compute preview state reactively with `$page.url`

## Testing
- `npm run validate` *(fails: existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846c2dab828832f9529005421ee06df