### PR TITLE
Add structured data for SEO

### DIFF
--- a/src/routes/(landing)/+page.svelte
+++ b/src/routes/(landing)/+page.svelte
@@ -48,6 +48,17 @@
     <meta name="twitter:title" content={$_('landing.slogan')} />
     <meta name="twitter:description" content={$_('landing.description')} />
     <meta name="twitter:image" content="https://tragos-locos.servitimo.net/og-image.png" />
+
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "MobileApplication",
+            "name": "Tragos Locos",
+            "operatingSystem": "iOS, Android, Web",
+            "applicationCategory": "GameApplication",
+            "description": "Tragos locos is a drinking party game app designed to elevate your social gatherings with endless fun."
+        }
+    </script>
 </svelte:head>
 
 <div class="bg-gray-50">


### PR DESCRIPTION
## Summary
- improve SEO for landing page with MobileApplication structured data

## Testing
- `npm run validate` *(fails: svelte-check found errors and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6846c85b0628832fbd6590528bf30375