### PR TITLE
Remove preview param

### DIFF
--- a/src/routes/(blog)/blog/[locale]/+page.svelte
+++ b/src/routes/(blog)/blog/[locale]/+page.svelte
@@ -6,8 +6,7 @@
     import { BlogUtilities } from "$lib/utils/BlogUtilities";
 
     const locale = getLocaleFromString($page.params.locale);
-    const preview = $page.url.searchParams.has('preview');
-    const posts: PostData[] = BlogUtilities.getPosts(locale, preview);
+    const posts: PostData[] = BlogUtilities.getPosts(locale);
 </script>
 
 <svelte:head>

--- a/src/routes/(blog)/blog/[locale]/[seoTag]/+page.svelte
+++ b/src/routes/(blog)/blog/[locale]/[seoTag]/+page.svelte
@@ -6,9 +6,7 @@
 
     const locale = getLocaleFromString($page.params.locale);
     const seoTag = $page.params.seoTag;
-    const preview = $page.url.searchParams.has('preview');
-
-    const post = BlogUtilities.getPostBySlug(locale, seoTag, preview);
+    const post = BlogUtilities.getPostBySlug(locale, seoTag);
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary
- remove unused `preview` query parameter from blog routes

## Testing
- `npm run validate` *(fails: svelte-check found 32 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6846c9a9b92c832f83a6fe674ef3c24e