### PR TITLE
Add day streak premium unlock

### DIFF
--- a/src/lib/UserInfo.ts
+++ b/src/lib/UserInfo.ts
@@ -8,3 +8,27 @@ export const getUserId = () => {
     }
     return userId;
 }
+
+export const incrementDaysPlayed = (): number => {
+    const days: string[] = JSON.parse(localStorage.getItem('daysPlayed') || '[]');
+    const today = new Date().toISOString().slice(0, 10);
+    if (!days.includes(today)) {
+        days.push(today);
+        localStorage.setItem('daysPlayed', JSON.stringify(days));
+    }
+
+    if (days.length >= 15) {
+        localStorage.setItem('premium', 'true');
+    }
+
+    return days.length;
+};
+
+export const isPremiumUser = (): boolean => {
+    return localStorage.getItem('premium') === 'true';
+};
+
+export const getDaysPlayed = (): number => {
+    const days: string[] = JSON.parse(localStorage.getItem('daysPlayed') || '[]');
+    return days.length;
+};

--- a/src/routes/(app)/play/[mode]/+page.svelte
+++ b/src/routes/(app)/play/[mode]/+page.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
     import Cards from "$lib/components/Cards.svelte";
     import PageContainer from "$lib/components/PageContainer.svelte";
+    import { onMount } from 'svelte';
+    import { incrementDaysPlayed } from "$lib/UserInfo";
+
+    onMount(() => {
+        incrementDaysPlayed();
+    });
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary
- track user play days and unlock Premium after 15 days
- increment day streak whenever a play page loads

## Testing
- `npm run build:app`

------
https://chatgpt.com/codex/tasks/task_e_6846cbd838bc832fbfa74a24e7b7695a