### PR TITLE
Add streak banner

### DIFF
--- a/src/lib/components/InGameBanner.svelte
+++ b/src/lib/components/InGameBanner.svelte
@@ -3,6 +3,8 @@
     import BottomSheet from "./BottomSheet.svelte";
     import { Share } from '@capacitor/share';
     import { shareApp } from "$lib/utils/Share";
+    import { getDaysPlayed } from "$lib/UserInfo";
+    import { _ } from '$lib/locales';
 
     const banners = [{
         id: 'laught',
@@ -15,7 +17,10 @@
         enabled: true,
     }, {
         id: 'suggest',
-        enabled: () => true, 
+        enabled: () => true,
+    }, {
+        id: 'streak',
+        enabled: () => getDaysPlayed() > 0,
     }];
     let showPremiumModal = false;
 
@@ -27,8 +32,9 @@
     const randomizeBanner = () => {
         banner = getRandomBanner().id;
     };
-    
+
     export let banner: string = getRandomBanner().id;
+    let daysPlayed: number = getDaysPlayed();
 
     const laught = async () => {
       try {
@@ -65,6 +71,10 @@
     <div class="w-full h-[50px] bg-gradient-to-r from-pink-500 to-purple-500 text-white flex items-center justify-between px-4 rounded-lg shadow-lg animate-pulse">
         <span class="text-sm font-bold">¡Comparte la diversión! 🎉</span>
         <button on:click={shareApp} class="bg-white text-purple-600 text-xs font-bold px-3 py-1 rounded-full shadow-md hover:bg-gray-200">📢 ¡Compártelo!</button>
+    </div>
+{:else if banner == 'streak'}
+    <div class="w-full h-[60px] bg-blue-100 text-black flex items-center justify-between px-4 rounded-lg shadow-lg">
+        <span class="text-sm font-bold text-gray-700">{$_('banners.streak', { days: daysPlayed })}</span>
     </div>
 {:else if banner == 'premium'}
     <div class="w-full h-[50px] bg-gradient-to-r from-green-400 to-blue-500 text-white flex items-center justify-between px-4 rounded-lg shadow-lg">

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -127,6 +127,9 @@
   "faqs": {
     "title": "Frequently Asked Questions"
   },
+  "banners": {
+    "streak": "You're on a {days}-day streak! Reach 15 to get one week of Premium free."
+  },
   "footer": {
     "blog": "Blog",
     "about_app": "About the App",

--- a/src/lib/locales/es.json
+++ b/src/lib/locales/es.json
@@ -123,6 +123,9 @@
     "text": "Descarga la app ahora y empieza a disfrutar de los mejores juegos en grupo.",
     "action": "Descargar ahora"
   },
+  "banners": {
+    "streak": "¡Llevas {days} días en racha! Llega a 15 para obtener una semana de Premium gratis."
+  },
   "footer": {
     "blog": "Blog",
     "about_app": "Sobre la App",


### PR DESCRIPTION
## Summary
- show days played streak banner in InGameBanner
- add i18n support for the new streak message

## Testing
- `npm run validate` *(fails: svelte-check found 33 errors and 25 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_6846cec0e15c832f8c7f15159da591be