### PR TITLE
Fix dynamic language attribute

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,6 +8,7 @@
 
     import { App } from '@capacitor/app';
     import { browser } from '$app/environment';
+    import { getLocale } from '$lib/locales';
     
     if (browser) {
         App.addListener('backButton', async () => {
@@ -16,6 +17,9 @@
     }
 
     onMount(async () => {
+      const lang = await getLocale()
+      document.documentElement.setAttribute('lang', lang)
+
       if (pwaInfo) {
         const { registerSW } = await import('virtual:pwa-register')
         registerSW({


### PR DESCRIPTION
## Summary
- set document's lang attribute dynamically in `+layout.svelte`

## Testing
- `npm run validate` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846c8f5b034832fb1a4785e971eb744