### PR TITLE
Add Best Friends game mode

### DIFF
--- a/src/lib/BestFriendsQuestions.ts
+++ b/src/lib/BestFriendsQuestions.ts
@@ -1,0 +1,75 @@
+import { Question } from "./questions";
+
+export const BestFriendsQuestions: Question[] = [
+    {
+        locales: {
+            es: "¿Cuál es el color favorito de {player1}? Adivina o bebe {shots} tragos.",
+            en: "What is {player1}'s favourite colour? Guess or drink {shots} shots."
+        },
+        tags: ['bestFriends']
+    },
+    {
+        locales: {
+            es: "{player1}, di la canción que más identifica a {player2} y si no la aciertas, bebe {shots}.",
+            en: "{player1}, name the song that best represents {player2}. If you fail, drink {shots}."
+        },
+        tags: ['bestFriends']
+    },
+    {
+        locales: {
+            es: "¿A qué edad se conocieron {player1} y {player2}? Si fallan, beban {shots}.",
+            en: "At what age did {player1} and {player2} meet? If you miss, drink {shots}."
+        },
+        tags: ['bestFriends']
+    },
+    {
+        locales: {
+            es: "{player1}, menciona la comida favorita de {player2} o bebe {shots} tragos.",
+            en: "{player1}, say {player2}'s favourite food or drink {shots} shots."
+        },
+        tags: ['bestFriends']
+    },
+    {
+        locales: {
+            es: "{player1}, ¿cuál es la mayor manía de {player2}? Si fallas bebe {shots}.",
+            en: "{player1}, what is {player2}'s biggest obsession? If you're wrong drink {shots}."
+        },
+        tags: ['bestFriends']
+    },
+    {
+        locales: {
+            es: "¿Cuál es la película favorita de {player1}? Adivinen o beban {shots} tragos.",
+            en: "What is {player1}'s favourite movie? Guess or drink {shots} shots."
+        },
+        tags: ['bestFriends']
+    },
+    {
+        locales: {
+            es: "{player1}, ¿dónde fue el último viaje de {player2}? Si no recuerdas, bebe {shots}.",
+            en: "{player1}, where was {player2}'s last trip? If you can't remember, drink {shots}."
+        },
+        tags: ['bestFriends']
+    },
+    {
+        locales: {
+            es: "{player1}, nombra la mascota de {player2} o bebe {shots} tragos.",
+            en: "{player1}, name {player2}'s pet or drink {shots} shots."
+        },
+        tags: ['bestFriends']
+    },
+    {
+        locales: {
+            es: "¿Cuál es el sueño pendiente de {player1}? Si nadie sabe, todos beben {shots}.",
+            en: "What is {player1}'s pending dream? If no one knows, everyone drinks {shots}."
+        },
+        tags: ['bestFriends']
+    },
+    {
+        locales: {
+            es: "{player1}, di cuál es el sobrenombre más usado para {player2}. Si te equivocas, bebe {shots}.",
+            en: "{player1}, say {player2}'s most used nickname. If you get it wrong, drink {shots}."
+        },
+        tags: ['bestFriends']
+    }
+];
+

--- a/src/lib/modes.ts
+++ b/src/lib/modes.ts
@@ -47,6 +47,18 @@ export const modes: { [key: string]: Mode } = {
             });
         }
     },
+    'best-friends': {
+        menuPriority: MenuPriority.GeneralMode,
+        icon: '/high-five.png',
+        pickCards: (questions: Question[], locale?: string, players?: any[]) => {
+            return getModeQuestions(questions, {
+                gameMode: 'bestFriends',
+                mode: 'basic',
+                locale,
+                players
+            });
+        }
+    },
     hot: {
         menuPriority: MenuPriority.GeneralMode,
         icon: '/plus-18-light.png',

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -1,8 +1,9 @@
 import { crazyQuestions } from "./crazyQuestions";
 import { hotQuestions } from "./hotQuestions";
 import { TeamQuestions } from "./TeamQuestions";
+import { BestFriendsQuestions } from "./BestFriendsQuestions";
 
-export type Tag = 'preparty' | '+18' | '+18-light' | 'challenge' | 'groupChallenge' | 'punishment' | 'groupPunishment' | 'reward' | 'drinkIf' | 'vote' | 'truth' | 'event' | 'christmas' | 'crazy' | 'teams';
+export type Tag = 'preparty' | '+18' | '+18-light' | 'challenge' | 'groupChallenge' | 'punishment' | 'groupPunishment' | 'reward' | 'drinkIf' | 'vote' | 'truth' | 'event' | 'christmas' | 'crazy' | 'teams' | 'bestFriends';
 
 export type Question = {
     index?: number;
@@ -4901,7 +4902,7 @@ export const questions: Question[] = [{
         en: "Everyone who has tried to learn a language and given up, drink {shots}"
     },
     tags: ["preparty"]
-}, ...crazyQuestions, ...hotQuestions, ...TeamQuestions];
+}, ...BestFriendsQuestions, ...crazyQuestions, ...hotQuestions, ...TeamQuestions];
 
 /*
 


### PR DESCRIPTION
## Summary
- add new question set `BestFriendsQuestions`
- extend question tags and include new question set in `questions.ts`
- register `best-friends` in `modes` with new icon

## Testing
- `npm run validate` *(fails: svelte-check found 33 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6846d56e72d4832fad9f75eaecb3d9ea