### PR TITLE
Add explore modes screen

### DIFF
--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -3,6 +3,7 @@
   "select_play_mode": "Let's select a mode to play!",
   "adjust_settings": "What are we going to adjust?",
   "player_name": "Player name",
+  "explore_modes": "Explore more modes",
   "modes": {
     "preparty": {
       "title": "PreParty",

--- a/src/lib/locales/es.json
+++ b/src/lib/locales/es.json
@@ -3,6 +3,7 @@
   "select_play_mode": "Como vamos a jugar?",
   "adjust_settings": "Que vamos a ajustar?",
   "player_name": "Nombre del/a jugador/a",
+  "explore_modes": "Explorar más modos",
   "modes": {
     "preparty": {
       "title": "PreFiesta",

--- a/src/routes/(app)/explore-modes/+page.svelte
+++ b/src/routes/(app)/explore-modes/+page.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+    import PageContainer from "$lib/components/PageContainer.svelte";
+    import BottomNavbar from "$lib/components/BottomNavbar.svelte";
+    import { _ } from "$lib/locales";
+
+    let titleCentered = true;
+    let titleStopedAnimating = false;
+
+    const moreModes = Array.from({ length: 20 }, (_, i) => ({
+        title: `Mode ${i + 1}`,
+        description: 'Coming soon',
+        icon: '/preparty.png'
+    }));
+
+    onMount(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 2500));
+        titleCentered = false;
+        await new Promise((resolve) => setTimeout(resolve, 800));
+        titleStopedAnimating = true;
+    });
+</script>
+
+<PageContainer class="relative flex flex-col items-center overflow-auto pb-5 pb-[50px]">
+    <div
+        class:absolute={!titleStopedAnimating}
+        class="{titleCentered ? '-translate-y-1/2 top-1/2' : 'translate-y-0 top-0'} h-fit-content flex w-screen animate-fade-in items-center justify-center text-center font-[Fredoka] text-6xl font-bold text-white transition-all duration-700"
+    >
+        {$_('explore_modes')}
+    </div>
+    {#if titleStopedAnimating}
+        <div class="flex w-full flex-col items-center justify-center gap-5 p-4 mt-[20px] max-w-lg">
+            {#each moreModes as mode, index}
+                <div class="justify-space-between flex w-full items-center gap-2 rounded-2xl bg-[794fea] bg-opacity-20 backdrop-blur-lg p-4 border border-solid border-white border-opacity-20">
+                    <div class="flex aspect-square h-[90px] w-[90px] items-center justify-center rounded-full bg-white bg-opacity-10 p-2">
+                        <img src={mode.icon} alt="" class="h-full w-full" />
+                    </div>
+                    <div class="flex w-full flex-col justify-center">
+                        <div class="text-3xl">{mode.title}</div>
+                        <div class="text-md text-justify font-[Ubuntu] font-normal leading-tight">{mode.description}</div>
+                    </div>
+                </div>
+            {/each}
+        </div>
+    {/if}
+</PageContainer>
+
+{#if titleStopedAnimating}
+    <div class="animation-duration-1200 animate-slide-up-fade">
+        <BottomNavbar/>
+    </div>
+{/if}

--- a/src/routes/(app)/select-mode/+page.svelte
+++ b/src/routes/(app)/select-mode/+page.svelte
@@ -62,9 +62,9 @@
     {#if titleStopedAnimating && Object.entries(modes)}
         <div class="flex w-full flex-col items-center justify-center gap-5 p-4 mt-[20px] max-w-lg">
             {#each  Object.entries(modes).filter(e => !e[1].isEnabled || e[1].isEnabled()) as [modeKey, mode], index}
-                <button 
-                    in:fly|global={{ x: index % 2 === 0 ? -200 : 200, duration: 300, delay: index * 250 }} 
-                    class="justify-space-between flex w-full items-center gap-2 rounded-2xl bg-[794fea] bg-opacity-20 backdrop-blur-lg p-4 border border-solid border-white border-opacity-20 shadow" on:click={onClick} 
+                <button
+                    in:fly|global={{ x: index % 2 === 0 ? -200 : 200, duration: 300, delay: index * 250 }}
+                    class="justify-space-between flex w-full items-center gap-2 rounded-2xl bg-[794fea] bg-opacity-20 backdrop-blur-lg p-4 border border-solid border-white border-opacity-20 shadow" on:click={onClick}
                     data-mode={modeKey} 
                     class:flex-row-reverse={index % 2 === 1}
                     data-umami-event="start-game"
@@ -80,6 +80,9 @@
                     </div>
                 </button>
             {/each}
+            <button class="w-full text-center bg-white bg-opacity-10 rounded-2xl p-4" on:click={() => goto('/explore-modes')}>
+                {$_('explore_modes')}
+            </button>
             <InGameBanner />
             {#if OriginChecker.isDev($page.url.href)}
                 <button class="w-full text-center bg-purple-500" on:click={() => showPremiumModal = true}>


### PR DESCRIPTION
## Summary
- add translation for new `explore_modes` label
- add a screen to explore more play modes
- link from mode selection to the new page

## Testing
- `npm run validate` *(fails: svelte-check found 33 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6846d5d9ce88832fa32b691215198455