### PR TITLE
Fix artifact action

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -38,7 +38,7 @@ jobs:
           ./gradlew assembleDebug
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app-debug.apk
           path: android/app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
## Summary
- fix pipeline build step to use `actions/upload-artifact@v4`

## Testing
- `npm run validate` *(fails: svelte-check found 33 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68471336f970832f89a7b438a163338f