### PR TITLE
Add haptic feedback utilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@capacitor/android": "^6.0.0",
         "@capacitor/app": "^6.0.1",
         "@capacitor/core": "^6.0.0",
+        "@capacitor/haptics": "^6.0.1",
         "@capacitor/ios": "^6.0.0",
         "@capacitor/share": "^6.0.3-dev-2141-20240903T111835.0",
         "@iconify-json/solar": "^1.2.2",
@@ -1747,6 +1748,15 @@
       "integrity": "sha512-xFy1/4qLFLp5WCIzIhtwUuVNNoz36+V7/BzHmLqgVJcvotc4MMjswW/TshnPQaLLujEOaLkA4h8ZJ0uoK3ImGg==",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/haptics": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/haptics/-/haptics-6.0.1.tgz",
+      "integrity": "sha512-Q8hedLwfwTSWEYc3eoATzkdKHBaIceYe5bd7FjxQCENNH0is5Ft0EjSRPz/xpTn39ebK0ooZBDBCwsyl6tjiTA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^6.0.0"
       }
     },
     "node_modules/@capacitor/ios": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@capacitor/android": "^6.0.0",
     "@capacitor/app": "^6.0.1",
     "@capacitor/core": "^6.0.0",
+    "@capacitor/haptics": "^6.0.1",
     "@capacitor/ios": "^6.0.0",
     "@capacitor/share": "^6.0.3-dev-2141-20240903T111835.0",
     "@iconify-json/solar": "^1.2.2",

--- a/src/lib/components/AddPlayerInput.svelte
+++ b/src/lib/components/AddPlayerInput.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { createEventDispatcher, onMount } from "svelte";
     import { _ } from "$lib/locales";
+    import { impact } from "$lib/utils/haptics";
     
     export let value: string = '';
     export let players: any[] = [];
@@ -40,11 +41,13 @@
 
     const clickAddPlayer = () => {
         addPlayer(value);
+        impact();
         value = '';
         input?.focus();
     };
 
     const clickPlay = () => {
+        impact();
         eventDispatcher('play');
     };
     

--- a/src/lib/components/CardSwiper/Card.svelte
+++ b/src/lib/components/CardSwiper/Card.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import src from "@midudev/tailwind-animations";
     import { onMount } from "svelte";
+    import { impact } from "$lib/utils/haptics";
 
 	export let element: HTMLElement;
 
@@ -22,11 +23,9 @@
 			setTimeout(() => {
 				animateTada = false;
 			}, 1000);
-			if (window.navigator?.vibrate) {
-				navigator.vibrate([200, 100, 200]);
-			}
-		}
-	}
+                        impact();
+                }
+        }
 </script>
 
 <div

--- a/src/lib/utils/haptics.ts
+++ b/src/lib/utils/haptics.ts
@@ -1,0 +1,38 @@
+import { Capacitor } from '@capacitor/core';
+import { Haptics, ImpactStyle, NotificationType } from '@capacitor/haptics';
+
+export const impact = async (style: ImpactStyle = ImpactStyle.Medium) => {
+    try {
+        if (Capacitor.isNativePlatform()) {
+            await Haptics.impact({ style });
+        } else if (window.navigator?.vibrate) {
+            navigator.vibrate([60, 20, 60]);
+        }
+    } catch (err) {
+        console.error('Haptics impact error', err);
+    }
+};
+
+export const notification = async (type: NotificationType = NotificationType.Success) => {
+    try {
+        if (Capacitor.isNativePlatform()) {
+            await Haptics.notification({ type });
+        } else if (window.navigator?.vibrate) {
+            navigator.vibrate([100, 50, 100]);
+        }
+    } catch (err) {
+        console.error('Haptics notification error', err);
+    }
+};
+
+export const vibrate = async (duration = 300) => {
+    try {
+        if (Capacitor.isNativePlatform()) {
+            await Haptics.vibrate({ duration });
+        } else if (window.navigator?.vibrate) {
+            navigator.vibrate(duration);
+        }
+    } catch (err) {
+        console.error('Haptics vibrate error', err);
+    }
+};


### PR DESCRIPTION
## Summary
- install `@capacitor/haptics`
- add a `haptics` utility with impact/notification/vibrate helpers
- trigger advanced haptics when cards with event tags appear
- trigger advanced haptics when adding a player or starting the game

## Testing
- `npm run validate` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846d4cc2ac4832f887084abf561542d