### PR TITLE
Fix prerendering for landing modes

### DIFF
--- a/src/routes/(landing)/modes/[mode]/+page.server.ts
+++ b/src/routes/(landing)/modes/[mode]/+page.server.ts
@@ -1,0 +1,6 @@
+import { modes } from '$lib/modes';
+import type { EntryGenerator } from './$types';
+
+export const entries: EntryGenerator = () => {
+    return Object.keys(modes).map((key) => ({ mode: key }));
+};


### PR DESCRIPTION
## Summary
- ensure `(landing)/modes/[mode]` can be prerendered by defining entries for all modes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build:app`

------
https://chatgpt.com/codex/tasks/task_e_6847df72229c832fbf0015efecd1ffc9