### PR TITLE
Add Resurrection Fest special mode

### DIFF
--- a/src/lib/ResurrectionFestQuestions.ts
+++ b/src/lib/ResurrectionFestQuestions.ts
@@ -1,0 +1,249 @@
+import { Question } from "./questions";
+
+export const ResurrectionFestQuestions: Question[] = [
+  {
+    locales: {
+      es: 'Si alguna vez has ido al Resurrection Fest, bebe {shots} tragos',
+      en: 'If you have ever been to Resurrection Fest, drink {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Nombra tu banda de metal favorita o bebe {shots} tragos',
+      en: 'Name your favorite metal band or drink {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: '¿Cuál fue tu primer concierto de metal? Comparte la historia o bebe {shots} tragos',
+      en: 'What was your first metal concert? Share the story or drink {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Todos los que lleven camiseta negra beben {shots} tragos',
+      en: 'Everyone wearing a black shirt drinks {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: '{player1} imita el grito gutural de tu vocalista favorito',
+      en: '{player1} imitate the growl of your favorite vocalist'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: '¿Cuál es tu himno del metal? Cántalo o bebe {shots} tragos',
+      en: 'What is your metal anthem? Sing it or drink {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Todos los que hayan hecho headbanging hasta marearse beben {shots} tragos',
+      en: 'Anyone who has headbanged until dizzy drinks {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: '{player1}, forma un pequeño mosh pit con {player2}',
+      en: '{player1}, start a small mosh pit with {player2}'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Si sabes tocar algún instrumento de metal, presúmelo ahora o bebe {shots} tragos',
+      en: 'If you can play a metal instrument, show it off or drink {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Todos los que tengan el pelo largo se reparten {shots} tragos',
+      en: 'Everyone with long hair distributes {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: '¿Qué banda te gustaría ver en el próximo Resurrection Fest? Responde o bebe {shots} tragos',
+      en: 'Which band would you like to see at the next Resurrection Fest? Answer or drink {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Canta el estribillo de una canción de metal o bebe {shots} tragos',
+      en: 'Sing the chorus of a metal song or drink {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Elige a alguien para que haga air guitar contigo durante 10 segundos',
+      en: 'Pick someone to air guitar with you for 10 seconds'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Si conoces la diferencia entre black metal y death metal, reparte {shots} tragos',
+      en: 'If you know the difference between black metal and death metal, distribute {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: '{player1} nombra tres bandas españolas de metal',
+      en: '{player1} name three Spanish metal bands'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Todos los que sepan quién es Lemmy beben {shots} tragos',
+      en: 'Anyone who knows who Lemmy is drinks {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Dinos tu festival de música favorito además del Resurrection Fest o bebe {shots} tragos',
+      en: 'Tell us your favorite music festival besides Resurrection Fest or drink {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: '¿Cuál ha sido el concierto más épico que has vivido? Cuenta la historia',
+      en: 'What has been the most epic concert you\'ve attended? Tell the story'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Si alguna vez has hecho crowd surfing, reparte {shots} tragos',
+      en: 'If you\'ve ever crowd surfed, distribute {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: '{player1} describe tu mejor recuerdo en un festival',
+      en: '{player1} describe your best festival memory'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Todos los que prefieran el metal clásico al moderno beben {shots} tragos',
+      en: 'Anyone who prefers classic metal over modern metal drinks {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: '{player1}, arma el cuerno del metal con la mano y grita \'yeah\'',
+      en: '{player1}, throw the metal horns and shout \'yeah\''
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Si has comprado merchandising en un concierto, bebe {shots} tragos',
+      en: 'If you have bought merch at a concert, drink {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Todos los que toquen un instrumento de cuerda reparten {shots} tragos',
+      en: 'Everyone who plays a string instrument distributes {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Cuenta la vez que más tarde llegaste a un concierto y bebe {shots} tragos',
+      en: 'Tell the time you arrived latest to a gig and drink {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: '{player1}, tararea un riff mítico y deja que adivinen la canción',
+      en: '{player1}, hum a classic riff and let others guess the song'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Todos los que tengan tatuajes de música metal beben {shots} tragos',
+      en: 'Anyone with metal-related tattoos drinks {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: '¿Qué grupo descubriste gracias al Resurrection Fest? Comparte o bebe {shots} tragos',
+      en: 'Which band did you discover thanks to Resurrection Fest? Share or drink {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Si nunca has estado en un pogo, bebe {shots} tragos',
+      en: 'If you have never been in a pit, drink {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: '{player1}, invéntate el nombre de un grupo de metal ficticio',
+      en: '{player1}, invent a name for a fictional metal band'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Todos los que hayan hecho air drum alguna vez reparten {shots} tragos',
+      en: 'Anyone who has ever air drummed distributes {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: '¿Cuál es la letra de metal más rara que recuerdas? Recítala o bebe {shots} tragos',
+      en: 'What is the weirdest metal lyric you remember? Recite it or drink {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: '{player1}, cuenta cuál sería tu cartel ideal para un festival',
+      en: '{player1}, tell us what your ideal festival lineup would be'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Todos los que alguna vez han dormido en tienda de campaña en un festival beben {shots} tragos',
+      en: 'Anyone who has ever camped at a festival drinks {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  },
+  {
+    locales: {
+      es: 'Si has hecho un viaje largo solo para ver un concierto, reparte {shots} tragos',
+      en: 'If you have travelled far just to see a gig, distribute {shots} shots'
+    },
+    tags: ['resurrectionFest']
+  }
+];

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -32,6 +32,10 @@
     "drinkIf": {
       "title": "Drink If",
       "description": "Read the card and drink if it applies to you. Perfect to break the ice."
+    },
+    "resurrectionFest": {
+      "title": "Resurrection Fest",
+      "description": "Metal and festival themed challenges to celebrate the Resurrection Fest."
     }
   },
   "blog": {

--- a/src/lib/locales/es.json
+++ b/src/lib/locales/es.json
@@ -32,6 +32,10 @@
     "drinkIf": {
       "title": "Drink If",
       "description": "Lee la carta y bebe si se aplica a ti. Perfecto para romper el hielo."
+    },
+    "resurrectionFest": {
+      "title": "Resurrection Fest",
+      "description": "Preguntas y retos sobre el festival y el metal para celebrar el Resurrection Fest."
     }
   },
   "blog": {

--- a/src/lib/modes.ts
+++ b/src/lib/modes.ts
@@ -141,6 +141,27 @@ export const modes: { [key: string]: Mode } = {
             });
         },
         isEnabled: () => false
+    },
+    resurrectionFest: {
+        menuPriority: MenuPriority.SeasonalMode,
+        icon: '/resurrectionfest.png',
+        isPublic: true,
+        isFeatured: false,
+        isEnabled: () => {
+            const date = new Date();
+            const year = date.getFullYear();
+            const start = new Date(year, 5, 24); // June 24
+            const end = new Date(year, 5, 30, 23, 59, 59, 999);
+            return date >= start && date <= end;
+        },
+        pickCards: (questions: Question[], locale?: string, players?: any[]) => {
+            return getModeQuestions(questions, {
+                gameMode: 'resurrectionFest',
+                mode: 'basic',
+                locale,
+                players
+            });
+        }
     }
 }
 

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -2,8 +2,9 @@ import { crazyQuestions } from "./crazyQuestions";
 import { hotQuestions } from "./hotQuestions";
 import { TeamQuestions } from "./TeamQuestions";
 import { BestFriendsQuestions } from "./BestFriendsQuestions";
+import { ResurrectionFestQuestions } from "./ResurrectionFestQuestions";
 
-export type Tag = 'preparty' | '+18' | '+18-light' | 'challenge' | 'groupChallenge' | 'punishment' | 'groupPunishment' | 'reward' | 'drinkIf' | 'vote' | 'truth' | 'event' | 'christmas' | 'crazy' | 'teams' | 'bestFriends';
+export type Tag = 'preparty' | '+18' | '+18-light' | 'challenge' | 'groupChallenge' | 'punishment' | 'groupPunishment' | 'reward' | 'drinkIf' | 'vote' | 'truth' | 'event' | 'christmas' | 'crazy' | 'teams' | 'bestFriends' | 'resurrectionFest';
 
 export type Question = {
     index?: number;
@@ -4902,7 +4903,7 @@ export const questions: Question[] = [{
         en: "Everyone who has tried to learn a language and given up, drink {shots}"
     },
     tags: ["preparty"]
-}, ...BestFriendsQuestions, ...crazyQuestions, ...hotQuestions, ...TeamQuestions];
+}, ...BestFriendsQuestions, ...crazyQuestions, ...hotQuestions, ...TeamQuestions, ...ResurrectionFestQuestions];
 
 /*
 


### PR DESCRIPTION
## Summary
- add Resurrection Fest question set with 35 festival-themed cards
- support new `resurrectionFest` tag and include questions
- create temporary `resurrectionFest` mode available June 24-30
- translate mode title/description to English and Spanish
- remove placeholder icon per feedback

## Testing
- `npm run validate` *(fails: svelte-check found 37 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6847ddf493b4832faaac85cc575560ac