### PR TITLE
Add related modes section

### DIFF
--- a/src/lib/components/RelatedModes.svelte
+++ b/src/lib/components/RelatedModes.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+    import { _ } from '$lib/locales';
+    import type { Mode } from '$lib/modes';
+    export let modesList: [string, Mode][] = [];
+</script>
+
+<div class="bg-white rounded-lg shadow p-6 mb-6 w-full">
+    <h3 class="text-xl font-semibold mb-4 text-center">{$_('related_modes')}</h3>
+    <ul class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {#each modesList as [key, mode]}
+            <li class="text-center">
+                <a href={`/modes/${key}/`} class="block hover:text-indigo-600 transition-colors">
+                    <img src={mode.icon} alt={$_(`modes.${key}.title`)} class="w-16 h-16 mx-auto mb-2" />
+                    <span class="block font-medium">{$_(`modes.${key}.title`)}</span>
+                </a>
+            </li>
+        {/each}
+    </ul>
+</div>

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -3,6 +3,7 @@
   "select_play_mode": "Let's select a mode to play!",
   "adjust_settings": "What are we going to adjust?",
   "player_name": "Player name",
+  "related_modes": "Related modes",
   "explore_modes": "Explore more modes",
   "modes": {
     "preparty": {

--- a/src/lib/locales/es.json
+++ b/src/lib/locales/es.json
@@ -3,6 +3,7 @@
   "select_play_mode": "Como vamos a jugar?",
   "adjust_settings": "Que vamos a ajustar?",
   "player_name": "Nombre del/a jugador/a",
+  "related_modes": "Modos relacionados",
   "explore_modes": "Explorar más modos",
   "modes": {
     "preparty": {

--- a/src/routes/(landing)/modes/[mode]/+page.svelte
+++ b/src/routes/(landing)/modes/[mode]/+page.svelte
@@ -3,20 +3,25 @@
   import { type Mode, modes } from '$lib/modes';
   import { _, getLocale } from '$lib/locales';
   import { onMount } from 'svelte';
+  import RelatedModes from '$lib/components/RelatedModes.svelte';
+  import '$lib/Shuffle';
   let modeKey: string = '';
   let mode: Mode | null = null;
   let examples: string[] = [];
   let modeStats = {
     duration: '30-60 min',
     players: '3+ jugadores',
-    category: 'General'
+    category: 'General',
+    totalCards: 0
   };
+  let relatedModes: [string, Mode][] = [];
 
   $: {
     const $pageVal = $page;
     modeKey = $pageVal.params.mode;
     mode = modes[modeKey];
     modeStats = getModeStats(modeKey);
+    relatedModes = getRelatedModes(modeKey);
   }
 
   $: if (modeKey && mode) {
@@ -63,6 +68,16 @@
       } catch {}
     }
     return stats;
+  }
+
+  function getRelatedModes(currentKey: string): [string, Mode][] {
+    const current = modes[currentKey];
+    if (!current) return [];
+    let pool = Object.entries(modes).filter(([key, m]) => key !== currentKey && (m.isPublic ?? true) && m.menuPriority === current.menuPriority);
+    if (pool.length < 3) {
+      pool = Object.entries(modes).filter(([key, m]) => key !== currentKey && (m.isPublic ?? true));
+    }
+    return pool.sort(() => Math.random() - 0.5).slice(0, 3);
   }
 </script>
 
@@ -116,6 +131,10 @@
         {/each}
       </div>
     </section>
+    {/if}
+
+    {#if relatedModes.length > 0}
+    <RelatedModes modesList={relatedModes} />
     {/if}
 
     <div class="text-center my-12">


### PR DESCRIPTION
## Summary
- add localized `related_modes` strings
- create `RelatedModes` component
- show related modes on each mode landing page

## Testing
- `npm run validate` *(fails: svelte-check found 36 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6847e4403c20832fa3d2d77a02ade223