### PR TITLE
Add header and footer to mode landing pages

### DIFF
--- a/src/routes/(landing)/modes/[mode]/+page.svelte
+++ b/src/routes/(landing)/modes/[mode]/+page.svelte
@@ -3,8 +3,9 @@
   import { type Mode, modes } from '$lib/modes';
   import { _, getLocale } from '$lib/locales';
   import { onMount } from 'svelte';
-  import RelatedModes from '$lib/components/RelatedModes.svelte';
-  import '$lib/Shuffle';
+import RelatedModes from '$lib/components/RelatedModes.svelte';
+import Footer from '$lib/components/Footer.svelte';
+import '$lib/Shuffle';
   let modeKey: string = '';
   let mode: Mode | null = null;
   let examples: string[] = [];
@@ -89,6 +90,17 @@
   {/if}
 </svelte:head>
 
+<header class="flex items-center w-full bg-white justify-between py-4 px-4">
+  <a class="flex items-center gap-2" aria-label="Tragos locos" href="/">
+    <img src="/favicon.png" class="w-8 h-8" alt="Tragos locos logo" />
+    <span class="hidden h-6 text-xl font-semibold sm:block">Tragos Locos</span>
+  </a>
+  <nav class="flex items-center space-x-4 leading-5">
+    <a class="hover:text-primary-500 m-1 font-medium text-gray-900" href="/blog">Blog</a>
+    <a class="hover:text-primary-500 m-1 font-medium text-gray-900" href="/sobre-la-app">Sobre la App</a>
+  </nav>
+</header>
+
 {#if mode}
   <div class="max-w-4xl mx-auto p-4">
     <header class="text-center my-8">
@@ -144,3 +156,5 @@
 {:else}
   <p class="text-center mt-20">Modo no encontrado</p>
 {/if}
+
+<Footer />


### PR DESCRIPTION
## Summary
- show site header on /modes/[mode] landing pages
- use common Footer component

## Testing
- `npm run validate` *(fails: svelte-check found errors and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6847e6499df0832fa466b3817462d0cb