### PR TITLE
Add Resurrection Fest Blog Post

### DIFF
--- a/src/lib/data/blogPosts/es/resurrection-fest-con-tragos-locos/PostContent.svelte
+++ b/src/lib/data/blogPosts/es/resurrection-fest-con-tragos-locos/PostContent.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+</script>
+
+<section class="space-y-8">
+    <div class="bg-gradient-to-r from-gray-800 to-purple-800 p-8 rounded-xl text-white">
+        <h1 class="text-4xl font-bold text-center mb-6">Resurrection Fest 2025: ¡Disfruta al Máximo con Tragos Locos! 🤘🍻</h1>
+        <p class="text-xl leading-relaxed">
+            El <strong>Resurrection Fest</strong> reúne a miles de amantes del metal cada verano en Viveiro. Para que la fiesta no pare entre concierto y concierto, nada mejor que echar unas rondas con <strong>Tragos Locos</strong>.
+        </p>
+    </div>
+
+    <div class="bg-white p-6 rounded-xl shadow-lg">
+        <h2 class="text-3xl font-bold mb-4">¿Por qué jugar Tragos Locos en el Resu?</h2>
+        <ul class="list-disc list-inside space-y-2 text-lg">
+            <li>Retos y preguntas con temática metalera para animar los momentos muertos.</li>
+            <li>Ideal para conocer a otros festivaleros y romper el hielo en el camping.</li>
+            <li>No necesitas accesorios extra, solo tu móvil y ganas de pasarlo bien.</li>
+        </ul>
+    </div>
+
+    <div class="bg-white p-6 rounded-xl shadow-lg">
+        <h2 class="text-3xl font-bold mb-4">Modo Resurrection Fest</h2>
+        <p class="text-lg mb-2">Durante la semana del festival, encontrarás un <strong>modo especial</strong> con cartas exclusivas inspiradas en tus bandas favoritas y la atmósfera única del Resu.</p>
+        <p class="text-lg">Aprovéchalo para retar a tus amigos con pruebas épicas mientras esperas al próximo concierto.</p>
+    </div>
+
+    <div class="bg-gray-900 text-white p-8 rounded-xl text-center space-y-4">
+        <h2 class="text-2xl font-bold">¡Que no pare la música ni la diversión!</h2>
+        <p>Descarga Tragos Locos y vive el Resurrection Fest como nunca.</p>
+        <div class="space-y-2">
+            <a href="/" class="inline-block bg-purple-600 px-6 py-3 rounded-lg font-semibold hover:bg-purple-700 transition">Descargar App</a>
+            <div>
+                <a href="/modes/resurrectionFest/" class="text-purple-300 underline">Más información del modo Resurrection Fest</a>
+            </div>
+        </div>
+    </div>
+</section>

--- a/src/lib/data/blogPosts/es/resurrection-fest-con-tragos-locos/postData.ts
+++ b/src/lib/data/blogPosts/es/resurrection-fest-con-tragos-locos/postData.ts
@@ -1,0 +1,13 @@
+import type { PostData } from "$lib/types/PostData";
+import PostContent from "./PostContent.svelte";
+
+export const postData: PostData = {
+    title: "Resurrection Fest 2025: ¡Disfruta al Máximo con Tragos Locos! 🤘🍻",
+    seoTag: "resurrection-fest-con-tragos-locos",
+    description: "Descubre cómo Tragos Locos puede acompañarte en el Resurrection Fest. Explora nuestro modo especial para el festival y lleva la diversión a otro nivel.",
+    date: new Date("2025-06-20"),
+    image: "/blog/best-drinking-questions-and-challenges/cover.png",
+    tags: ["Resurrection Fest", "festival", "modo especial"],
+    lang: "es",
+    component: PostContent
+};


### PR DESCRIPTION
## Summary
- add new Spanish blog post about the Resurrection Fest special mode
- reference an existing cover image instead of adding a new one

## Testing
- `npm run validate` *(fails: svelte-check found 36 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6847e6ad5d3c832f84bd46b5df85a565