### PR TITLE
Add breadcrumb schema to modes pages

### DIFF
--- a/src/routes/(landing)/modes/+page.svelte
+++ b/src/routes/(landing)/modes/+page.svelte
@@ -2,6 +2,7 @@
   import { _ } from '$lib/locales';
   import { modes } from '$lib/modes';
   import Footer from '$lib/components/Footer.svelte';
+  import { SchemaGenerator } from '$lib/utils/SchemaGenerator';
 
   const modeEntries = Object.entries(modes).filter(([key, mode]) => mode.isPublic ?? true);
 </script>
@@ -10,6 +11,12 @@
   <title>{$_('modes_page.title')} | Tragos Locos</title>
   <meta name="description" content={$_('modes_page.description')} />
   <link rel="canonical" href="https://tragos-locos.servitimo.net/modes/" />
+  {@html `<script type="application/ld+json">${JSON.stringify(
+    SchemaGenerator.getBreadcrumbs([
+      { name: 'Tragos Locos', url: 'https://tragos-locos.servitimo.net/' },
+      { name: $_('modes_page.title'), url: 'https://tragos-locos.servitimo.net/modes/' }
+    ])
+  )}</script>`}
 </svelte:head>
 
 <header class="flex items-center w-full bg-white justify-between py-4 px-4">

--- a/src/routes/(landing)/modes/[mode]/+page.svelte
+++ b/src/routes/(landing)/modes/[mode]/+page.svelte
@@ -5,6 +5,7 @@
   import { onMount } from 'svelte';
 import RelatedModes from '$lib/components/RelatedModes.svelte';
 import Footer from '$lib/components/Footer.svelte';
+import { SchemaGenerator } from '$lib/utils/SchemaGenerator';
 import '$lib/Shuffle';
   let modeKey: string = '';
   let mode: Mode | null = null;
@@ -87,6 +88,13 @@ import '$lib/Shuffle';
     <title>{$_(`modes.${modeKey}.title`)} | Tragos Locos</title>
     <meta name="description" content={$_(`modes.${modeKey}.description`)} />
     <link rel="canonical" href={`https://tragos-locos.servitimo.net/modes/${modeKey}/`} />
+    {@html `<script type="application/ld+json">${JSON.stringify(
+      SchemaGenerator.getBreadcrumbs([
+        { name: 'Tragos Locos', url: 'https://tragos-locos.servitimo.net/' },
+        { name: $_('modes_page.title'), url: 'https://tragos-locos.servitimo.net/modes/' },
+        { name: $_(`modes.${modeKey}.title`), url: `https://tragos-locos.servitimo.net/modes/${modeKey}/` }
+      ])
+    )}</script>`}
   {/if}
 </svelte:head>
 


### PR DESCRIPTION
## Summary
- add SchemaGenerator import to `modes` landing page
- inject breadcrumb JSON‑LD on `/modes`
- add SchemaGenerator import to mode detail page
- inject breadcrumb JSON‑LD on `/modes/[mode]`

## Testing
- `npm run validate` *(fails: svelte-check found 36 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6847eb7c5dc4832f8ea17705d2e0b0e3