### PR TITLE
Fix locale setter

### DIFF
--- a/src/lib/locales/index.ts
+++ b/src/lib/locales/index.ts
@@ -22,9 +22,7 @@ export const getLocale = async (): Promise<string> => {
 
 export const setLocale = async (newLocale: any): Promise<void> => {
     return new Promise((resolve) => {
-        locale.subscribe(() => {
-            locale.set(locale);
-            resolve();
-        });
+        locale.set(newLocale);
+        resolve();
     });
 }


### PR DESCRIPTION
## Summary
- update `setLocale` to use the passed parameter when updating the locale

## Testing
- `npm run validate` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847fab86560832fabf443cede8acc93