### PR TITLE
Use Capacitor Preferences

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@capacitor/core": "^6.0.0",
         "@capacitor/haptics": "^6.0.1",
         "@capacitor/ios": "^6.0.0",
+        "@capacitor/preferences": "^6.0.3",
         "@capacitor/share": "^6.0.3-dev-2141-20240903T111835.0",
         "@iconify-json/solar": "^1.2.2",
         "@iconify-json/tabler": "^1.2.16",
@@ -1765,6 +1766,15 @@
       "integrity": "sha512-HaeW68KisBd/7TmavzPDlL2bpoDK5AjR2ZYrqU4TlGwM88GtQfvduBCAlSCj20X0w/4+rWMkseD9dAAkacjiyQ==",
       "peerDependencies": {
         "@capacitor/core": "^6.1.0"
+      }
+    },
+    "node_modules/@capacitor/preferences": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/preferences/-/preferences-6.0.3.tgz",
+      "integrity": "sha512-3I1BbhhCBTMBziVvr0fU7RCRXqGvhUW/apHLRJSaJAWonASya5rp6AWsHv1lW1tkF0avUOMwp6e7iNA4UUGu8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^6.0.0"
       }
     },
     "node_modules/@capacitor/share": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@capacitor/core": "^6.0.0",
     "@capacitor/haptics": "^6.0.1",
     "@capacitor/ios": "^6.0.0",
+    "@capacitor/preferences": "^6.0.3",
     "@capacitor/share": "^6.0.3-dev-2141-20240903T111835.0",
     "@iconify-json/solar": "^1.2.2",
     "@iconify-json/tabler": "^1.2.16",

--- a/src/lib/PlayerStorage.ts
+++ b/src/lib/PlayerStorage.ts
@@ -1,0 +1,45 @@
+import { Preferences } from '@capacitor/preferences';
+
+let players: any[] = [];
+let teams: any[] = [];
+
+export const loadPlayers = async () => {
+    if (typeof window === 'undefined') return;
+    const sessionData = sessionStorage.getItem('players');
+    if (sessionData) {
+        await Preferences.set({ key: 'players', value: sessionData });
+        sessionStorage.removeItem('players');
+    }
+    const { value } = await Preferences.get({ key: 'players' });
+    players = value ? JSON.parse(value) : [];
+};
+
+export const getPlayers = () => players;
+
+export const setPlayers = async (list: any[]) => {
+    players = list;
+    await Preferences.set({ key: 'players', value: JSON.stringify(players) });
+};
+
+export const clearPlayers = async () => {
+    players = [];
+    await Preferences.remove({ key: 'players' });
+};
+
+export const loadTeams = async () => {
+    if (typeof window === 'undefined') return;
+    const legacy = localStorage.getItem('teams');
+    if (legacy) {
+        await Preferences.set({ key: 'teams', value: legacy });
+        localStorage.removeItem('teams');
+    }
+    const { value } = await Preferences.get({ key: 'teams' });
+    teams = value ? JSON.parse(value) : [];
+};
+
+export const getTeams = () => teams;
+
+export const setTeams = async (list: any[]) => {
+    teams = list;
+    await Preferences.set({ key: 'teams', value: JSON.stringify(teams) });
+};

--- a/src/lib/components/Cards.svelte
+++ b/src/lib/components/Cards.svelte
@@ -15,6 +15,7 @@
     import { shareApp } from '$lib/utils/Share';
     import type { Team } from '$lib/types/Team';
     import { _ } from '$lib/locales';
+    import { loadPlayers, getPlayers, loadTeams, getTeams } from '$lib/PlayerStorage';
 
     const mode = $page.params.mode as string;
     let filteredQuestions: Question[] = [];
@@ -31,14 +32,16 @@
     let teams: Team[] = [];
     let umami: umami.umami | undefined;
 
-	onMount(async () => {
-        players = JSON.parse(sessionStorage.getItem('players') || '[]');
+        onMount(async () => {
+        await loadPlayers();
+        players = getPlayers();
         if (!players || players.length == 0) goto('/select-mode');
         locale = await getLocale();
         filteredQuestions = modes[mode].pickCards(questions, locale, players);
-        teams = JSON.parse(localStorage.getItem('teams') || '[]');
+        await loadTeams();
+        teams = getTeams();
         umami = window.umami;
-	});
+        });
 
 	let swipe: (direction?: 'left' | 'right') => void;
     let undoSwipe: () => void;

--- a/src/lib/modes.ts
+++ b/src/lib/modes.ts
@@ -6,6 +6,7 @@ import { _ } from "$lib/locales";
 import { Team } from "./types/Team";
 import { getRandomizedTeamNames, getRandomTeamName } from "./TeamNames";
 import { getLocaleFromString } from "./types/Locales";
+import { setTeams } from './PlayerStorage';
 
 enum MenuPriority {
     GeneralMode = 0,
@@ -99,7 +100,7 @@ export const modes: { [key: string]: Mode } = {
             randomizedPlayers?.forEach((player, index) => {
                 teams[index % 2].players.push(player);
             });
-            localStorage.setItem('teams', JSON.stringify(teams));
+            setTeams(teams);
             return getModeQuestions(questions, {
                 gameMode: 'teams',
                 mode: 'basic',

--- a/src/routes/(app)/+page.svelte.old
+++ b/src/routes/(app)/+page.svelte.old
@@ -50,8 +50,10 @@
         });
         input.$on('play', () => {
             if (players.length > 0) {
-                sessionStorage.setItem('players', JSON.stringify(players));
-                window.location.replace('/select-mode');
+                import('$lib/PlayerStorage').then(async ({ setPlayers }) => {
+                    await setPlayers(players);
+                    window.location.replace('/select-mode');
+                });
             }
         });
     });

--- a/src/routes/(app)/add-players/+page.svelte
+++ b/src/routes/(app)/add-players/+page.svelte
@@ -5,6 +5,7 @@
     import AddPlayerInput from "$lib/components/AddPlayerInput.svelte";
     import { goto } from "$app/navigation";
     import { _ } from "$lib/locales";
+    import { loadPlayers, getPlayers, setPlayers } from "$lib/PlayerStorage";
 
     let titleCentered = true;
     let titleStopedAnimating = false;
@@ -13,7 +14,8 @@
     let players: any[] = [];
 
     onMount(async () => {
-        players = JSON.parse(sessionStorage.getItem('players') || '[]');
+        await loadPlayers();
+        players = getPlayers();
         const AppSys = (await import('@capacitor/app')).App;
         AppSys.addListener('backButton', (data: any) => {
             AppSys.exitApp();
@@ -25,9 +27,9 @@
         titleStopedAnimating = true;
     });
 
-    const play = () => {
+    const play = async () => {
         if (players.length > 0) {
-            sessionStorage.setItem('players', JSON.stringify(players));
+            await setPlayers(players);
             goto('/select-mode');
         }
     };

--- a/src/routes/(app)/mode/[mode]/info/+page.svelte
+++ b/src/routes/(app)/mode/[mode]/info/+page.svelte
@@ -7,6 +7,7 @@ import { goto } from '$app/navigation';
 import PageContainer from '$lib/components/PageContainer.svelte';
 import { fly, fade } from 'svelte/transition';
     import { questions } from '$lib/questions';
+import { loadPlayers, getPlayers } from '$lib/PlayerStorage';
 
 let modeKey: string = '';
 let mode: Mode|null = null;
@@ -47,8 +48,8 @@ async function getExampleCards(modeKey: string): Promise<string[]> {
             'Ejemplo de tarjeta 4'
         ];
     }
-    const players = JSON.parse(sessionStorage.getItem('players') || '[]');
-    console.log(players);
+    await loadPlayers();
+    const players = getPlayers();
     return (mode?.pickCards(questions, locale, players) || []).map((card) => {
         return card.locales[locale];
     }).slice(2, 6);

--- a/src/routes/(app)/select-mode/+page.svelte
+++ b/src/routes/(app)/select-mode/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { goto } from "$app/navigation";
     import { App } from '@capacitor/app';
-	import { browser } from '$app/environment';
+        import { browser } from '$app/environment';
     import PageContainer from "$lib/components/PageContainer.svelte";
     import { onMount } from "svelte";
     import { fly } from "svelte/transition";
@@ -13,6 +13,7 @@
     import PremiumFeatureBottomSheet from "$lib/components/BottomSheets/PremiumFeatureBottomSheet.svelte";
     import InGameBanner from "$lib/components/InGameBanner.svelte";
     import { initialize, interstitial, rewardVideo, showConsent } from "$lib/Admob";
+    import { loadPlayers, getPlayers } from "$lib/PlayerStorage";
     
     let titleCentered = true;
     let titleStopedAnimating = false;
@@ -21,6 +22,8 @@
     let showPremiumModal = false;
 
     onMount(async () => {
+        await loadPlayers();
+        playerCount = getPlayers().length;
         await new Promise((resolve) => setTimeout(resolve, 2500));
         titleCentered = false;
         await new Promise((resolve) => setTimeout(resolve, 800));
@@ -34,10 +37,9 @@
     });
 
     if (browser) {
-	    App.addListener('backButton', async () => {
-		    window.history.back();
-	    });
-        playerCount = JSON.parse(sessionStorage.getItem('players') || '[]').length;
+            App.addListener('backButton', async () => {
+                    window.history.back();
+            });
         if (playerCount === 0) goto('/add-players');
     }
 

--- a/src/routes/(landing)/modes/[mode]/+page.svelte
+++ b/src/routes/(landing)/modes/[mode]/+page.svelte
@@ -8,6 +8,7 @@ import Footer from '$lib/components/Footer.svelte';
 import { SchemaGenerator } from '$lib/utils/SchemaGenerator';
 import { questions } from '$lib/questions';
 import '$lib/Shuffle';
+import { loadPlayers, getPlayers } from '$lib/PlayerStorage';
   let modeKey: string = '';
   let mode: Mode | null = null;
   let examples: string[] = [];
@@ -45,7 +46,8 @@ import '$lib/Shuffle';
         'Ejemplo de tarjeta 4'
       ];
     }
-    const players = JSON.parse(sessionStorage.getItem('players') || '[]');
+    await loadPlayers();
+    const players = getPlayers();
     return (mode?.pickCards(questions, locale, players) || []).map(card => card.locales[locale]).slice(2, 6);
   }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,11 +4,13 @@
     import '../app.css';
     import { PUBLIC_UMAMI_WEBSITE_ID	} from '$lib/config';
     import { OriginChecker } from '$lib/OriginChecker';
-    import { page } from '$app/stores';
+import { page } from '$app/stores';
 
     import { App } from '@capacitor/app';
     import { browser } from '$app/environment';
-    import { getLocale } from '$lib/locales';
+import { getLocale } from '$lib/locales';
+import { loadUserInfo } from '$lib/UserInfo';
+import { loadPlayers, loadTeams } from '$lib/PlayerStorage';
     
     if (browser) {
         App.addListener('backButton', async () => {
@@ -17,6 +19,9 @@
     }
 
     onMount(async () => {
+      await loadUserInfo();
+      await loadPlayers();
+      await loadTeams();
       const lang = await getLocale()
       document.documentElement.setAttribute('lang', lang)
 


### PR DESCRIPTION
## Summary
- replace local/session storage with Capacitor Preferences for player and user data
- add helper utilities for storing players and teams
- migrate any existing storage on startup
- update pages to use the new helpers
- install `@capacitor/preferences`

## Testing
- `npm run validate` *(fails: svelte-check found 36 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6847fabe6354832f9e1c753c51814013