### PR TITLE
Add optional play reminders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@capacitor/core": "^6.0.0",
         "@capacitor/haptics": "^6.0.1",
         "@capacitor/ios": "^6.0.0",
+        "@capacitor/local-notifications": "^6.1.2",
         "@capacitor/share": "^6.0.3-dev-2141-20240903T111835.0",
         "@iconify-json/solar": "^1.2.2",
         "@iconify-json/tabler": "^1.2.16",
@@ -1765,6 +1766,15 @@
       "integrity": "sha512-HaeW68KisBd/7TmavzPDlL2bpoDK5AjR2ZYrqU4TlGwM88GtQfvduBCAlSCj20X0w/4+rWMkseD9dAAkacjiyQ==",
       "peerDependencies": {
         "@capacitor/core": "^6.1.0"
+      }
+    },
+    "node_modules/@capacitor/local-notifications": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/local-notifications/-/local-notifications-6.1.2.tgz",
+      "integrity": "sha512-LZrwkuh+EaIbpIOeqotUUB31MWA3BF+Hdf9ZdOK9MVJyHG7hL27ja/mx50tO6VW3+nlaXSeygkRZPIuuV4UQRQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^6.0.0"
       }
     },
     "node_modules/@capacitor/share": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@capacitor/core": "^6.0.0",
     "@capacitor/haptics": "^6.0.1",
     "@capacitor/ios": "^6.0.0",
+    "@capacitor/local-notifications": "^6.1.2",
     "@capacitor/share": "^6.0.3-dev-2141-20240903T111835.0",
     "@iconify-json/solar": "^1.2.2",
     "@iconify-json/tabler": "^1.2.16",

--- a/src/lib/UserInfo.ts
+++ b/src/lib/UserInfo.ts
@@ -1,4 +1,5 @@
-import {v4 as uuidv4} from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
+import { scheduleDailyReminder } from './utils/reminders';
 
 export const getUserId = () => {
     let userId = localStorage.getItem('userId');
@@ -21,6 +22,7 @@ export const incrementDaysPlayed = (): number => {
         localStorage.setItem('premium', 'true');
     }
 
+    scheduleDailyReminder();
     return days.length;
 };
 

--- a/src/lib/utils/reminders.ts
+++ b/src/lib/utils/reminders.ts
@@ -1,0 +1,73 @@
+import { Capacitor } from '@capacitor/core';
+import { LocalNotifications } from '@capacitor/local-notifications';
+
+export const requestNotificationPermission = async () => {
+    try {
+        if (Capacitor.isNativePlatform()) {
+            await LocalNotifications.requestPermissions();
+        }
+    } catch (err) {
+        console.error('Notification permission error', err);
+    }
+};
+
+export const getRemindersEnabled = (): boolean => {
+    return localStorage.getItem('remindersEnabled') === 'true';
+};
+
+export const setRemindersEnabled = (value: boolean) => {
+    localStorage.setItem('remindersEnabled', value.toString());
+};
+
+export const cancelReminders = async () => {
+    if (!Capacitor.isNativePlatform()) return;
+    try {
+        await LocalNotifications.cancel({ notifications: [] });
+    } catch (err) {
+        console.error('Cancel reminders error', err);
+    }
+};
+
+export const scheduleDailyReminder = async () => {
+    if (!Capacitor.isNativePlatform() || !getRemindersEnabled()) return;
+
+    try {
+        const perm = await LocalNotifications.checkPermissions();
+        if (perm.display !== 'granted') return;
+
+        await cancelReminders();
+
+        const now = new Date();
+        const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+
+        await LocalNotifications.schedule({
+            notifications: [
+                {
+                    id: 1,
+                    title: '¡Hora de jugar Tragos Locos!',
+                    body: 'Vuelve y continúa con la diversión.',
+                    schedule: { at: tomorrow },
+                },
+            ],
+        });
+
+        const friday = new Date(now);
+        friday.setDate(now.getDate() + ((5 - now.getDay() + 7) % 7));
+        friday.setHours(18, 0, 0, 0);
+
+        if (friday.getTime() > now.getTime()) {
+            await LocalNotifications.schedule({
+                notifications: [
+                    {
+                        id: 2,
+                        title: 'Es viernes por la noche \uD83C\uDF7B',
+                        body: 'Reúne a tus amigos y juega Tragos Locos.',
+                        schedule: { at: friday },
+                    },
+                ],
+            });
+        }
+    } catch (err) {
+        console.error('Schedule reminder error', err);
+    }
+};

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -10,14 +10,28 @@
     import Featurebase from "$lib/components/Featurebase.svelte";
     import BottomSheet from "$lib/components/BottomSheet.svelte";
     import LanguageSelector from "$lib/components/BottomSheets/LanguageSelector.svelte";
+    import { requestNotificationPermission, getRemindersEnabled, setRemindersEnabled, cancelReminders, scheduleDailyReminder } from '$lib/utils/reminders';
 
     let titleCentered = true;
     let titleStopedAnimating = false;
+
+    let remindersEnabled = getRemindersEnabled();
 
     const modals = {
         suggestQuestion: false,
         sendFeedback: false,
         languageSelector: false
+    };
+
+    const toggleReminders = async () => {
+        remindersEnabled = !remindersEnabled;
+        setRemindersEnabled(remindersEnabled);
+        if (remindersEnabled) {
+            await requestNotificationPermission();
+            await scheduleDailyReminder();
+        } else {
+            await cancelReminders();
+        }
     };
 
     onMount(async () => {
@@ -61,6 +75,16 @@
                     <div class="text-3xl">Language</div>
                 </div>
             </button>
+
+            <div class="justify-space-between flex w-full items-center gap-2 rounded-2xl bg-white bg-opacity-10 p-4">
+                <div class="flex w-full flex-col justify-center text-left">
+                    <div class="text-3xl">Daily reminders</div>
+                </div>
+                <label class="relative inline-flex items-center cursor-pointer">
+                    <input type="checkbox" class="sr-only peer" bind:checked={remindersEnabled} on:change={toggleReminders} />
+                    <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none rounded-full peer peer-checked:bg-[#794fea] after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:after:translate-x-full"></div>
+                </label>
+            </div>
         </div>
     {/if}
 </PageContainer>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
     import { PUBLIC_UMAMI_WEBSITE_ID	} from '$lib/config';
     import { OriginChecker } from '$lib/OriginChecker';
     import { page } from '$app/stores';
+    import { requestNotificationPermission } from '$lib/utils/reminders';
 
     import { App } from '@capacitor/app';
     import { browser } from '$app/environment';
@@ -37,6 +38,8 @@
           }
         })
       }
+
+      await requestNotificationPermission()
     })
     
     $: webManifest = pwaInfo ? pwaInfo.webManifest.linkTag : ''


### PR DESCRIPTION
## Summary
- install `@capacitor/local-notifications`
- notify permission request on startup
- create reminders util
- schedule reminders when playing a game
- allow toggling reminders from settings

## Testing
- `npm run validate`

------
https://chatgpt.com/codex/tasks/task_e_6847fafa2c58832fa15302410c9a7cfa