### PR TITLE
Add Duel game mode

### DIFF
--- a/src/lib/DuelQuestions.ts
+++ b/src/lib/DuelQuestions.ts
@@ -1,0 +1,32 @@
+import { Question } from './questions';
+
+export const DuelQuestions: Question[] = [
+  {
+    locales: {
+      es: '⚔️ DUELO: {player1} vs {player2}. ¿Quién cuenta la historia más vergonzosa sin reírse? El resto decide. El perdedor bebe {shots} tragos.',
+      en: '⚔️ DUEL: {player1} vs {player2}. Who can tell the most embarrassing story without laughing? Others decide. Loser drinks {shots} shots.'
+    },
+    tags: ['duel']
+  },
+  {
+    locales: {
+      es: '⚡ RETO RÁPIDO: {player1} vs {player2}. Repetid 3 veces: "Tres tristes tigres tragaban trigo". El primero en fallar bebe {shots} tragos.',
+      en: '⚡ SPEED CHALLENGE: {player1} vs {player2}. Repeat 3 times: "Tres tristes tigres tragaban trigo". First to fail drinks {shots} shots.'
+    },
+    tags: ['duel']
+  },
+  {
+    locales: {
+      es: '🎯 DUELO DE VERDADES: {player1} vs {player2}. Confiesad algo que nunca habéis dicho. El resto vota. El perdedor bebe {shots} tragos.',
+      en: '🎯 TRUTH DUEL: {player1} vs {player2}. Confess something never said aloud. Others vote. Loser drinks {shots} shots.'
+    },
+    tags: ['duel']
+  },
+  {
+    locales: {
+      es: '💪 DUELO DE RETOS: {player1} vs {player2}. Competencia de flexiones durante 30 segundos. Quien haga menos bebe {shots} tragos.',
+      en: '💪 DARE DUEL: {player1} vs {player2}. Push-up contest for 30 seconds. Whoever does fewer drinks {shots} shots.'
+    },
+    tags: ['duel']
+  }
+];

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -37,6 +37,10 @@
     "resurrectionFest": {
       "title": "Resurrection Fest",
       "description": "Metal and festival themed challenges to celebrate the Resurrection Fest."
+    },
+    "duel": {
+      "title": "Duel",
+      "description": "1v1 challenges. Loser drinks."
     }
   },
   "blog": {

--- a/src/lib/locales/es.json
+++ b/src/lib/locales/es.json
@@ -131,6 +131,10 @@
     "resurrectionFest": {
       "title": "Resurrection Fest",
       "description": "Preguntas y retos sobre el festival y el metal para celebrar el Resurrection Fest."
+    },
+    "duel": {
+      "title": "Duelos",
+      "description": "Enfrentamientos 1v1 donde el perdedor bebe."
     }
   },
   "blog": {

--- a/src/lib/modes.ts
+++ b/src/lib/modes.ts
@@ -176,6 +176,20 @@ export const modes: { [key: string]: Mode } = {
                 players
             });
         }
+    },
+    duel: {
+        menuPriority: MenuPriority.GeneralMode,
+        icon: '/duel.png',
+        isPublic: true,
+        isFeatured: true,
+        pickCards: (questions: Question[], locale?: string, players?: any[]) => {
+            return getModeQuestions(questions, {
+                gameMode: 'duel',
+                mode: 'basic',
+                locale,
+                players
+            });
+        }
     }
 }
 

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -3,8 +3,27 @@ import { hotQuestions } from "./hotQuestions";
 import { TeamQuestions } from "./TeamQuestions";
 import { BestFriendsQuestions } from "./BestFriendsQuestions";
 import { ResurrectionFestQuestions } from "./ResurrectionFestQuestions";
+import { DuelQuestions } from "./DuelQuestions";
 
-export type Tag = 'preparty' | '+18' | '+18-light' | 'challenge' | 'groupChallenge' | 'punishment' | 'groupPunishment' | 'reward' | 'drinkIf' | 'vote' | 'truth' | 'event' | 'christmas' | 'crazy' | 'teams' | 'bestFriends' | 'resurrectionFest';
+export type Tag =
+  | 'preparty'
+  | '+18'
+  | '+18-light'
+  | 'challenge'
+  | 'groupChallenge'
+  | 'punishment'
+  | 'groupPunishment'
+  | 'reward'
+  | 'drinkIf'
+  | 'vote'
+  | 'truth'
+  | 'event'
+  | 'christmas'
+  | 'crazy'
+  | 'teams'
+  | 'bestFriends'
+  | 'resurrectionFest'
+  | 'duel';
 
 export type Question = {
     index?: number;
@@ -4903,7 +4922,14 @@ export const questions: Question[] = [{
         en: "Everyone who has tried to learn a language and given up, drink {shots}"
     },
     tags: ["preparty"]
-}, ...BestFriendsQuestions, ...crazyQuestions, ...hotQuestions, ...TeamQuestions, ...ResurrectionFestQuestions];
+},
+  ...DuelQuestions,
+  ...BestFriendsQuestions,
+  ...crazyQuestions,
+  ...hotQuestions,
+  ...TeamQuestions,
+  ...ResurrectionFestQuestions
+];
 
 /*
 


### PR DESCRIPTION
## Summary
- introduce simple Duel questions
- include Duel mode configuration
- add Duel translations for English and Spanish
- register Duel questions in question list

## Testing
- `npm run validate` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_68480b250844832fbeef2bfafd6fcf66