### PR TITLE
Add Cascade Drinking mode

### DIFF
--- a/src/lib/CascadeQuestions.ts
+++ b/src/lib/CascadeQuestions.ts
@@ -1,0 +1,25 @@
+import { Question } from './questions';
+
+export const CascadeQuestions: Question[] = [
+  {
+    locales: {
+      es: 'Si {player1} no puede nombrar 5 países en 10 segundos, bebe 2 tragos.',
+      en: 'If {player1} cannot name 5 countries in 10 seconds, drink 2 shots.'
+    },
+    tags: ['cascade', 'cascade-trigger']
+  },
+  {
+    locales: {
+      es: 'Si {player1} bebe, {player2} debe imitar a un animal.',
+      en: 'If {player1} drinks, {player2} must imitate an animal.'
+    },
+    tags: ['cascade', 'cascade-effect']
+  },
+  {
+    locales: {
+      es: 'Si {player2} se ríe durante la imitación, todos beben 1 trago.',
+      en: 'If {player2} laughs during the imitation, everyone drinks 1 shot.'
+    },
+    tags: ['cascade', 'cascade-end']
+  }
+];

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -41,6 +41,10 @@
     "duel": {
       "title": "Duel",
       "description": "1v1 challenges. Loser drinks."
+    },
+    "cascade": {
+      "title": "Cascade Drinking",
+      "description": "One action triggers another. Keep the chain going!"
     }
   },
   "blog": {

--- a/src/lib/locales/es.json
+++ b/src/lib/locales/es.json
@@ -135,6 +135,10 @@
     "duel": {
       "title": "Duelos",
       "description": "Enfrentamientos 1v1 donde el perdedor bebe."
+    },
+    "cascade": {
+      "title": "Cascada de Bebida",
+      "description": "Una acción desencadena otra en cadena. ¡No la rompas!"
     }
   },
   "blog": {

--- a/src/lib/modes.ts
+++ b/src/lib/modes.ts
@@ -190,6 +190,20 @@ export const modes: { [key: string]: Mode } = {
                 players
             });
         }
+    },
+    cascade: {
+        menuPriority: MenuPriority.GeneralMode,
+        icon: '/cascade.png',
+        isPublic: true,
+        isFeatured: false,
+        pickCards: (questions: Question[], locale?: string, players?: any[]) => {
+            return getModeQuestions(questions, {
+                gameMode: 'cascade',
+                mode: 'cascade',
+                locale,
+                players
+            });
+        }
     }
 }
 
@@ -198,7 +212,7 @@ function getModeQuestions(questions: Question[], options: {
     players?: any[],
     teams?: Team[],
     gameMode: Tag
-    mode: 'basic' | 'compound' | 'progressive'
+    mode: 'basic' | 'compound' | 'progressive' | 'cascade'
 }): Question[] {
     questions.map((question, index) => {
         question.index = index;
@@ -287,6 +301,17 @@ function getModeQuestions(questions: Question[], options: {
         });
 
         return finalQuestions;
+    } else if (options.mode === 'cascade') {
+        let cascadeQuestions = questions.filter((question) => {
+            if (!question.tags?.includes('cascade')) return false;
+            if (options.locale && !question.locales[options.locale]) return false;
+            return true;
+        });
+        cascadeQuestions = fillPlaceholders(cascadeQuestions, {
+            players: options.players,
+            locale: options.locale
+        });
+        return cascadeQuestions;
     }
     return [];
 }

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -4,6 +4,7 @@ import { TeamQuestions } from "./TeamQuestions";
 import { BestFriendsQuestions } from "./BestFriendsQuestions";
 import { ResurrectionFestQuestions } from "./ResurrectionFestQuestions";
 import { DuelQuestions } from "./DuelQuestions";
+import { CascadeQuestions } from "./CascadeQuestions";
 
 export type Tag =
   | 'preparty'
@@ -23,7 +24,11 @@ export type Tag =
   | 'teams'
   | 'bestFriends'
   | 'resurrectionFest'
-  | 'duel';
+  | 'duel'
+  | 'cascade'
+  | 'cascade-trigger'
+  | 'cascade-effect'
+  | 'cascade-end';
 
 export type Question = {
     index?: number;
@@ -4928,7 +4933,8 @@ export const questions: Question[] = [{
   ...crazyQuestions,
   ...hotQuestions,
   ...TeamQuestions,
-  ...ResurrectionFestQuestions
+  ...ResurrectionFestQuestions,
+  ...CascadeQuestions
 ];
 
 /*


### PR DESCRIPTION
## Summary
- add cascade drinking questions
- support cascade tags in questions
- expose new cascade game mode
- update i18n strings for cascade mode

## Testing
- `npm run validate` *(fails: 35 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6848107e3bb4832faa5301157108f14d