### PR TITLE
Add progressive mode translations

### DIFF
--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -22,6 +22,10 @@
       "title": "Hot",
       "description": "Oriented towards the most perverse questions, get ready to reveal your most intimate secrets."
     },
+    "progressive": {
+      "title": "Progressive",
+      "description": "Start with lighter challenges and gradually raise the intensity for an escalating party."
+    },
     "teams": {
       "title": "Teams",
       "description": "Too many payers? Let's make teams and play! The best way to play with a lot of people."

--- a/src/lib/locales/es.json
+++ b/src/lib/locales/es.json
@@ -116,6 +116,10 @@
       "title": "Hot",
       "description": "Orientado a preguntas más perversas, ¿listo para revelar tus secretos más intimos?"
     },
+    "progressive": {
+      "title": "Progresivo",
+      "description": "Comienza con retos ligeros y aumenta la intensidad poco a poco para que la fiesta no pare."
+    },
     "teams": {
       "title": "Equipos",
       "description": "¿Demasiados jugadores? ¡Hagamos equipos y juguemos! La mejor manera de jugar con mucha gente."


### PR DESCRIPTION
## Summary
- add title and description for the new Progressive mode in English and Spanish locale files

## Testing
- `npm run validate` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848153deb4c832fbd8de11e2e23680f