### PR TITLE
Add San Juan questions and mode

### DIFF
--- a/src/lib/SanJuanQuestions.ts
+++ b/src/lib/SanJuanQuestions.ts
@@ -1,0 +1,74 @@
+import { Question } from "./questions";
+
+export const SanJuanQuestions: Question[] = [
+  {
+    locales: {
+      es: 'Si alguna vez has saltado una hoguera en San Juan, bebe {shots} tragos',
+      en: 'If you have ever jumped over a bonfire on San Juan, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Cuéntanos tu tradición favorita de San Juan o bebe {shots} tragos',
+      en: 'Share your favourite San Juan tradition or drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, elige a alguien para que te acompañe a mojar los pies en el mar. Si se niega, bebe {shots} tragos',
+      en: '{player1}, choose someone to go wet your feet in the sea. If they refuse, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Todos los que hayan escrito deseos en papel para quemar esta noche beben {shots} tragos',
+      en: 'Everyone who has written wishes on paper to burn tonight drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si alguna vez te has bañado en el mar a medianoche en San Juan, reparte {shots} tragos',
+      en: 'If you have ever taken a midnight swim on San Juan, distribute {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, imita el sonido de un petardo o bebe {shots} tragos',
+      en: '{player1}, imitate the sound of a firecracker or drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Brinda por tu recuerdo más divertido de una noche de San Juan y bebe {shots} tragos',
+      en: 'Toast to your funniest San Juan memory and drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'El último en gritar ¡Feliz San Juan! bebe {shots} tragos',
+      en: 'The last one to shout Happy San Juan! drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si alguna vez has perdido algo en la playa durante San Juan, bebe {shots} tragos',
+      en: 'If you ever lost something on the beach during San Juan, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, cuéntanos tu deseo para este San Juan o bebe {shots} tragos',
+      en: '{player1}, tell us your wish for this San Juan or drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  }
+];

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -42,6 +42,10 @@
       "title": "Resurrection Fest",
       "description": "Metal and festival themed challenges to celebrate the Resurrection Fest."
     },
+    "sanJuan": {
+      "title": "San Juan",
+      "description": "Challenges and questions to celebrate St John's Eve."
+    },
     "duel": {
       "title": "Duel",
       "description": "1v1 challenges. Loser drinks."

--- a/src/lib/locales/es.json
+++ b/src/lib/locales/es.json
@@ -136,6 +136,10 @@
       "title": "Resurrection Fest",
       "description": "Preguntas y retos sobre el festival y el metal para celebrar el Resurrection Fest."
     },
+    "sanJuan": {
+      "title": "San Juan",
+      "description": "Retos y preguntas para celebrar la Noche de San Juan."
+    },
     "duel": {
       "title": "Duelos",
       "description": "Enfrentamientos 1v1 donde el perdedor bebe."

--- a/src/lib/modes.ts
+++ b/src/lib/modes.ts
@@ -178,6 +178,27 @@ export const modes: { [key: string]: Mode } = {
             });
         }
     },
+    sanJuan: {
+        menuPriority: MenuPriority.SeasonalMode,
+        icon: '/preparty.png',
+        isPublic: true,
+        isFeatured: false,
+        isEnabled: () => {
+            const date = new Date();
+            const year = date.getFullYear();
+            const start = new Date(year, 5, 20); // June 20
+            const end = new Date(year, 5, 25, 23, 59, 59, 999);
+            return date >= start && date <= end;
+        },
+        pickCards: (questions: Question[], locale?: string, players?: any[]) => {
+            return getModeQuestions(questions, {
+                gameMode: 'sanJuan',
+                mode: 'basic',
+                locale,
+                players
+            });
+        }
+    },
     duel: {
         menuPriority: MenuPriority.BetaMode,
         icon: '/duel.png',

--- a/src/lib/questions.ts
+++ b/src/lib/questions.ts
@@ -3,6 +3,7 @@ import { hotQuestions } from "./hotQuestions";
 import { TeamQuestions } from "./TeamQuestions";
 import { BestFriendsQuestions } from "./BestFriendsQuestions";
 import { ResurrectionFestQuestions } from "./ResurrectionFestQuestions";
+import { SanJuanQuestions } from "./SanJuanQuestions";
 import { DuelQuestions } from "./DuelQuestions";
 import { CascadeQuestions } from "./CascadeQuestions";
 
@@ -24,6 +25,7 @@ export type Tag =
   | 'teams'
   | 'bestFriends'
   | 'resurrectionFest'
+  | 'sanJuan'
   | 'duel'
   | 'cascade'
   | 'cascade-trigger'
@@ -4933,6 +4935,7 @@ export const questions: Question[] = [{
   ...crazyQuestions,
   ...hotQuestions,
   ...TeamQuestions,
+  ...SanJuanQuestions,
   ...ResurrectionFestQuestions,
   ...CascadeQuestions
 ];


### PR DESCRIPTION
## Summary
- add San Juan themed questions
- integrate San Juan mode and tag in questions
- localize San Juan mode in Spanish and English
- include icon for San Juan mode
- remove San Juan icon

## Testing
- `npm run validate` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ff2064838832fbeb39d9a1645d804