### PR TITLE
Add 50 San Juan questions

### DIFF
--- a/src/lib/SanJuanQuestions.ts
+++ b/src/lib/SanJuanQuestions.ts
@@ -70,5 +70,355 @@ export const SanJuanQuestions: Question[] = [
       en: '{player1}, tell us your wish for this San Juan or drink {shots} shots'
     },
     tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Todos los que est\u00e9n vestidos de blanco beben {shots} tragos',
+      en: 'Everyone dressed in white drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si alguna vez has comido sardinas en la noche de San Juan, bebe {shots} tragos',
+      en: 'If you\'ve ever eaten sardines on San Juan night, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, dirige una cuenta regresiva hasta la medianoche o bebe {shots} tragos',
+      en: '{player1}, lead a countdown to midnight or drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si alguna vez has encendido una hoguera de San Juan, bebe {shots} tragos',
+      en: 'If you\'ve ever lit a San Juan bonfire, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, canta un coro t\u00edpico de San Juan o bebe {shots} tragos',
+      en: '{player1}, sing a typical San Juan chant or drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si conoces alguna leyenda de brujas sobre San Juan, reparte {shots} tragos',
+      en: 'If you know any witch legends about San Juan, distribute {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Todos los que hayan arrojado algo al mar para olvidarlo beben {shots} tragos',
+      en: 'Everyone who has thrown something into the sea to forget it drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, recita una rima sobre el fuego o bebe {shots} tragos',
+      en: '{player1}, recite a rhyme about fire or drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si alguna vez has celebrado San Juan fuera de tu ciudad, bebe {shots} tragos',
+      en: 'If you\'ve ever celebrated San Juan outside your city, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Todos los que lleven una corona de flores beben {shots} tragos',
+      en: 'Everyone wearing a flower crown drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si alguna vez viste amanecer despu\u00e9s de celebrar San Juan, reparte {shots} tragos',
+      en: 'If you\'ve ever watched the sunrise after celebrating San Juan, distribute {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, cuenta cu\u00e1l fue la hoguera m\u00e1s impresionante que has visto o bebe {shots} tragos',
+      en: '{player1}, tell us about the most impressive bonfire you\'ve seen or drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Todos los que hayan bailado descalzos en la arena beben {shots} tragos',
+      en: 'Everyone who has danced barefoot on the sand drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1} y {player2}, hagan un baile alrededor de una hoguera imaginaria o beban {shots} tragos',
+      en: '{player1} and {player2}, dance around an imaginary bonfire or drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si alguna vez te quemaste con un petardo en San Juan, bebe {shots} tragos',
+      en: 'If you\'ve ever been burned by a firework on San Juan, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Todos los que lleven sandalias beben {shots} tragos',
+      en: 'Everyone wearing sandals drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, reta a alguien a correr con una bengala imaginaria; quien se niegue bebe {shots} tragos',
+      en: '{player1}, challenge someone to run with an imaginary sparkler; whoever refuses drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si alguna vez has tirado petardos en San Juan, bebe {shots} tragos',
+      en: 'If you\'ve ever set off firecrackers on San Juan, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, comparte una superstici\u00f3n que sigues en San Juan o bebe {shots} tragos',
+      en: '{player1}, share a superstition you follow on San Juan or drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Todos los que hayan hecho adivinaci\u00f3n con plomo o cera beben {shots} tragos',
+      en: 'Everyone who has done fortune telling with melted lead or wax drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, sopla un deseo hacia el mar en m\u00edmica o bebe {shots} tragos',
+      en: '{player1}, mime blowing a wish into the sea or drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si alguna vez realizaste un ritual de buena suerte en San Juan, bebe {shots} tragos',
+      en: 'If you\'ve ever performed a good luck ritual on San Juan, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Todos los que lleven joyas deben quitarse una pieza o beber {shots} tragos',
+      en: 'Everyone wearing jewellery must remove one piece or drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, elige una canci\u00f3n de verano; si al grupo no le gusta, bebe {shots} tragos',
+      en: '{player1}, pick a summer song; if the group doesn\'t like it, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Todos los que hayan cocinado en la playa en San Juan beben {shots} tragos',
+      en: 'Everyone who has cooked on the beach during San Juan drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si conociste a alguien especial en una noche de San Juan, bebe {shots} tragos',
+      en: 'If you met someone special on a San Juan night, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, imita el sonido de las olas; si no convence, bebe {shots} tragos',
+      en: '{player1}, imitate the sound of the waves; if it\'s not convincing, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Todos los que se hayan perdido alguna fiesta de San Juan por trabajo o estudios beben {shots} tragos',
+      en: 'Everyone who has missed a San Juan celebration due to work or studies drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si viajaste a otra ciudad solo para celebrar San Juan, bebe {shots} tragos',
+      en: 'If you traveled to another city just to celebrate San Juan, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, prop\u00f3n un brindis por el grupo; si no se te ocurre nada, bebe {shots} tragos',
+      en: '{player1}, propose a toast for the group; if you can\'t think of one, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Todos los que hayan tomado selfies junto a la hoguera beben {shots} tragos',
+      en: 'Everyone who has taken selfies by the bonfire drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, elige a alguien para bailar contigo; si se niega, bebe {shots} tragos',
+      en: '{player1}, choose someone to dance with you; if they refuse, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si alguna vez has visto fuegos artificiales en San Juan, bebe {shots} tragos',
+      en: 'If you\'ve ever watched fireworks at San Juan, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Todos los que hayan decorado la casa o la terraza para San Juan beben {shots} tragos',
+      en: 'Everyone who decorated their home or terrace for San Juan drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, cuenta un mito o leyenda sobre San Juan o bebe {shots} tragos',
+      en: '{player1}, tell a myth or legend about San Juan or drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si alguna vez escribiste tu deseo con lim\u00f3n para quemarlo, bebe {shots} tragos',
+      en: 'If you ever wrote your wish with lemon juice to burn it, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Todos los que tengan fotos antiguas de San Juan en el m\u00f3vil beben {shots} tragos',
+      en: 'Everyone who has old San Juan photos on their phone drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, inicia un c\u00e1ntico de "San Juan, San Juan" hasta que todos se unan o bebe {shots} tragos',
+      en: '{player1}, start a chant of "San Juan, San Juan" until everyone joins in or drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si alguna vez saltaste nueve olas pidiendo deseos, bebe {shots} tragos',
+      en: 'If you\'ve ever jumped nine waves while making wishes, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Todos los que hayan tra\u00eddo toalla o manta para la playa beben {shots} tragos',
+      en: 'Everyone who brought a towel or blanket for the beach drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si recogiste hierbas para un ritual de San Juan, bebe {shots} tragos',
+      en: 'If you\'ve gathered herbs for a San Juan ritual, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, nombra una comida t\u00edpica de esta celebraci\u00f3n o bebe {shots} tragos',
+      en: '{player1}, name a traditional food of this celebration or drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Todos los que hayan danzado en c\u00edrculo alrededor del fuego beben {shots} tragos',
+      en: 'Everyone who has danced in a circle around the fire drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si alguna vez quemaste objetos viejos para renovarte, bebe {shots} tragos',
+      en: 'If you\'ve burned old items to renew yourself, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, brinda por la nueva estaci\u00f3n o bebe {shots} tragos',
+      en: '{player1}, toast to the new season or drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Todos los que hayan probado la queimada u otra bebida t\u00edpica beben {shots} tragos',
+      en: 'Everyone who has tried queimada or another typical drink drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si alguna vez asististe a un gran festival de San Juan, bebe {shots} tragos',
+      en: 'If you\'ve ever attended a big San Juan festival, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: '{player1}, act\u00faa como si encendieras un fuego artificial; si no te esfuerzas, bebe {shots} tragos',
+      en: '{player1}, pretend to light a firework; if you don\'t give it your all, drink {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Todos los que hayan acabado con arena en los zapatos tras San Juan beben {shots} tragos',
+      en: 'Everyone who ended up with sand in their shoes after San Juan drinks {shots} shots'
+    },
+    tags: ['sanJuan']
+  },
+  {
+    locales: {
+      es: 'Si alguna vez publicaste sobre San Juan en redes sociales, bebe {shots} tragos',
+      en: 'If you\'ve ever posted about San Juan on social networks, drink {shots} shots'
+    },
+    tags: ['sanJuan']
   }
 ];


### PR DESCRIPTION
## Summary
- expand `SanJuanQuestions.ts` with 50 new unique questions for the San Juan mode

## Testing
- `npm run validate` *(fails: svelte-check found errors and warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684ff57d5e48832f9d7ef860ec2f2db1