### PR TITLE
Add SEO description HTML translations for modes

### DIFF
--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -8,51 +8,63 @@
   "modes": {
     "preparty": {
       "title": "PreParty",
-      "description": "Best for animate the party. Light fun for any group."
+      "description": "Best for animate the party. Light fun for any group.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-blue-100 via-purple-100 to-pink-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-purple-800 mb-2\">🍹 PreParty Warm-Up</h2><p class=\"text-base text-gray-700\">Kick off the night with quick icebreakers and lighthearted challenges. Perfect to get everyone laughing before the real party starts.</p><p class=\"text-sm text-gray-500 mt-2\">🎉 Works great on mobile. Ideal for any gathering.</p></div>"
     },
     "crazy": {
       "title": "Tragos Locos",
-      "description": "Take your party to the next level. The most daring questions. Only for the brave."
+      "description": "Take your party to the next level. The most daring questions. Only for the brave.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-red-100 via-orange-100 to-yellow-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-red-800 mb-2\">🤪 Crazy Mode</h2><p class=\"text-base text-gray-700\">Wild dares and outrageous questions turn any night into a hilarious memory. Only for the brave who love surprises.</p><p class=\"text-sm text-gray-500 mt-2\">🚀 Best for parties looking to push limits.</p></div>"
     },
     "best-friends": {
       "title": "Best Friends",
-      "description": "Best for playing with close friends. Let's get to know each other better."
+      "description": "Best for playing with close friends. Let's get to know each other better.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-green-100 via-blue-100 to-purple-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-green-800 mb-2\">👯 Best Friends</h2><p class=\"text-base text-gray-700\">Discover secrets and memories with those closest to you. Personal questions spark laughter and strengthen bonds.</p><p class=\"text-sm text-gray-500 mt-2\">💬 Great for small groups that know each other well.</p></div>"
     },
     "hot": {
       "title": "Hot",
-      "description": "Oriented towards the most perverse questions, get ready to reveal your most intimate secrets."
+      "description": "Oriented towards the most perverse questions, get ready to reveal your most intimate secrets.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-pink-100 via-red-100 to-purple-200 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-pink-800 mb-2\">🔥 Hot Mode</h2><p class=\"text-base text-gray-700\">Spicy dares and intimate questions turn up the heat. Perfect for couples or daring groups ready to reveal secrets.</p><p class=\"text-sm text-gray-500 mt-2\">💖 Play responsibly and keep the mood fun.</p></div>"
     },
     "progressive": {
       "title": "Progressive",
-      "description": "Start with lighter challenges and gradually raise the intensity for an escalating party."
+      "description": "Start with lighter challenges and gradually raise the intensity for an escalating party.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-indigo-100 via-purple-100 to-pink-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-indigo-800 mb-2\">📈 Progressive Mode</h2><p class=\"text-base text-gray-700\">Start with easy challenges and gradually raise the intensity. Perfect for building suspense and energy throughout the night.</p><p class=\"text-sm text-gray-500 mt-2\">⏳ Ideal when you want a smooth escalation.</p></div>"
     },
     "teams": {
       "title": "Teams",
-      "description": "Too many payers? Let's make teams and play! The best way to play with a lot of people."
+      "description": "Too many payers? Let's make teams and play! The best way to play with a lot of people.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-teal-100 via-green-100 to-blue-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-teal-800 mb-2\">🏆 Team Battles</h2><p class=\"text-base text-gray-700\">Split into groups and compete in hilarious challenges. Collaboration and rivalry make huge parties unforgettable.</p><p class=\"text-sm text-gray-500 mt-2\">🤝 Perfect for large gatherings.</p></div>"
     },
     "christmas": {
       "title": "Christmas",
-      "description": "The christmas is here! Let's have fun with chsitmas themed questions."
+      "description": "The christmas is here! Let's have fun with chsitmas themed questions.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-green-100 via-red-100 to-yellow-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-green-800 mb-2\">🎄 Christmas Edition</h2><p class=\"text-base text-gray-700\">Seasonal questions and festive dares to celebrate with holiday cheer. Bring the spirit of Christmas to your party.</p><p class=\"text-sm text-gray-500 mt-2\">🎅 Only available in December.</p></div>"
     },
     "drinkIf": {
       "title": "Drink If",
-      "description": "Read the card and drink if it applies to you. Perfect to break the ice."
+      "description": "Read the card and drink if it applies to you. Perfect to break the ice.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-yellow-100 via-orange-100 to-red-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-yellow-800 mb-2\">🥂 Drink If...</h2><p class=\"text-base text-gray-700\">Read a card and drink if it applies to you. Simple rules that guarantee laughs and quick bonding.</p><p class=\"text-sm text-gray-500 mt-2\">🍻 Great as an icebreaker.</p></div>"
     },
     "resurrectionFest": {
       "title": "Resurrection Fest",
-      "description": "Metal and festival themed challenges to celebrate the Resurrection Fest."
+      "description": "Metal and festival themed challenges to celebrate the Resurrection Fest.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-gray-100 via-red-100 to-gray-200 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-red-800 mb-2\">🤘 Resurrection Fest</h2><p class=\"text-base text-gray-700\">Metal vibes and festival-themed challenges for fans of the legendary event. Rock out and drink with fellow metalheads.</p><p class=\"text-sm text-gray-500 mt-2\">🎸 Available during festival dates.</p></div>"
     },
     "sanJuan": {
       "title": "San Juan",
-      "description": "Challenges and questions to celebrate St John's Eve."
+      "description": "Challenges and questions to celebrate St John's Eve.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-yellow-100 via-pink-100 to-purple-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-purple-800 mb-2\">🔥 St John's Eve Drinking Game</h2><p class=\"text-base text-gray-700\">Celebrate St John's Eve like never before with wild dares, bold questions and lots of fire. Bring the best beach party game to your bonfire and create magical memories.</p><p class=\"text-sm text-gray-500 mt-2\">🌙 Mobile friendly. Perfect for San Juan 2025 celebrations.</p></div>"
     },
     "duel": {
       "title": "Duel",
-      "description": "1v1 challenges. Loser drinks."
+      "description": "1v1 challenges. Loser drinks.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-purple-100 via-indigo-100 to-red-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-purple-800 mb-2\">⚔️ Duel Mode</h2><p class=\"text-base text-gray-700\">Face off one-on-one in quick challenges. Winner boasts, loser drinks. Intense showdowns keep everyone on edge.</p><p class=\"text-sm text-gray-500 mt-2\">🏅 Try it when you want direct competition.</p></div>"
     },
     "cascade": {
       "title": "Cascade Drinking",
-      "description": "One action triggers another. Keep the chain going!"
+      "description": "One action triggers another. Keep the chain going!",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-blue-100 via-cyan-100 to-teal-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-blue-800 mb-2\">💧 Cascade Drinking</h2><p class=\"text-base text-gray-700\">Each action triggers the next in a chain reaction. Keep the flow going and see who breaks first.</p><p class=\"text-sm text-gray-500 mt-2\">🌊 Fun for groups that love momentum.</p></div>"
     }
   },
   "blog": {

--- a/src/lib/locales/es.json
+++ b/src/lib/locales/es.json
@@ -102,51 +102,63 @@
   "modes": {
     "preparty": {
       "title": "PreFiesta",
-      "description": "La mejor opción para animar la fiesta. ¡Buenas jugadas para cualquier grupo!"
+      "description": "La mejor opción para animar la fiesta. ¡Buenas jugadas para cualquier grupo!",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-blue-100 via-purple-100 to-pink-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-purple-800 mb-2\">🍹 PreFiesta para Calentar Motores</h2><p class=\"text-base text-gray-700\">Empieza la noche con preguntas rápidas y retos ligeros que rompen el hielo y animan a todos antes de la fiesta grande.</p><p class=\"text-sm text-gray-500 mt-2\">🎉 Compatible con móviles. Ideal para cualquier reunión.</p></div>"
     },
     "crazy": {
       "title": "Tragos Locos",
-      "description": "Lleva tu fiesta al siguiente nivel. Las preguntas más atrevidas. Solo para los valientes."
+      "description": "Lleva tu fiesta al siguiente nivel. Las preguntas más atrevidas. Solo para los valientes.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-red-100 via-orange-100 to-yellow-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-red-800 mb-2\">🤪 Modo Tragos Locos</h2><p class=\"text-base text-gray-700\">Retos salvajes y preguntas disparatadas que convierten cualquier reunión en un recuerdo épico. Solo para valientes que buscan sorpresas.</p><p class=\"text-sm text-gray-500 mt-2\">🚀 El favorito para fiestas que quieren romper los límites.</p></div>"
     },
     "best-friends": {
       "title": "Best Friends",
-      "description": "Mejor para jugar con amigos cercanos. ¡Vamos a conocernos mejor!"
+      "description": "Mejor para jugar con amigos cercanos. ¡Vamos a conocernos mejor!",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-green-100 via-blue-100 to-purple-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-green-800 mb-2\">👯 Modo Best Friends</h2><p class=\"text-base text-gray-700\">Descubre secretos y anécdotas con tus amigos más cercanos. Preguntas personales que sacan risas y refuerzan la amistad.</p><p class=\"text-sm text-gray-500 mt-2\">💬 Ideal para grupos reducidos que se conocen bien.</p></div>"
     },
     "hot": {
       "title": "Hot",
-      "description": "Orientado a preguntas más perversas, ¿listo para revelar tus secretos más intimos?"
+      "description": "Orientado a preguntas más perversas, ¿listo para revelar tus secretos más intimos?",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-pink-100 via-red-100 to-purple-200 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-pink-800 mb-2\">🔥 Modo Hot</h2><p class=\"text-base text-gray-700\">Desafíos picantes y preguntas íntimas para subir la temperatura. Perfecto para parejas o grupos atrevidos dispuestos a revelar secretos.</p><p class=\"text-sm text-gray-500 mt-2\">💖 Juega con responsabilidad y mantén el ambiente divertido.</p></div>"
     },
     "progressive": {
       "title": "Progresivo",
-      "description": "Comienza con retos ligeros y aumenta la intensidad poco a poco para que la fiesta no pare."
+      "description": "Comienza con retos ligeros y aumenta la intensidad poco a poco para que la fiesta no pare.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-indigo-100 via-purple-100 to-pink-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-indigo-800 mb-2\">📈 Modo Progresivo</h2><p class=\"text-base text-gray-700\">Comienza con retos suaves y sube la intensidad poco a poco. Perfecto para mantener la emoción y la energía durante toda la noche.</p><p class=\"text-sm text-gray-500 mt-2\">⏳ Ideal para una subida gradual de tensión.</p></div>"
     },
     "teams": {
       "title": "Equipos",
-      "description": "¿Demasiados jugadores? ¡Hagamos equipos y juguemos! La mejor manera de jugar con mucha gente."
+      "description": "¿Demasiados jugadores? ¡Hagamos equipos y juguemos! La mejor manera de jugar con mucha gente.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-teal-100 via-green-100 to-blue-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-teal-800 mb-2\">🏆 Competencia por Equipos</h2><p class=\"text-base text-gray-700\">Divídanse en grupos y compitan con desafíos divertidos. La colaboración y la rivalidad hacen que las fiestas grandes sean inolvidables.</p><p class=\"text-sm text-gray-500 mt-2\">🤝 Perfecto para reuniones multitudinarias.</p></div>"
     },
     "christmas": {
       "title": "Navidad",
-      "description": "Mejor para fiestas de Navidad. ¡Veamos preguntas relaccionadas con la nieve!"
+      "description": "Mejor para fiestas de Navidad. ¡Veamos preguntas relaccionadas con la nieve!",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-green-100 via-red-100 to-yellow-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-green-800 mb-2\">🎄 Edición Navideña</h2><p class=\"text-base text-gray-700\">Preguntas temáticas y retos festivos para celebrar con el mejor espíritu navideño. Lleva la magia de la Navidad a tu fiesta.</p><p class=\"text-sm text-gray-500 mt-2\">🎅 Disponible solo en diciembre.</p></div>"
     },
     "drinkIf": {
       "title": "Drink If",
-      "description": "Lee la carta y bebe si se aplica a ti. Perfecto para romper el hielo."
+      "description": "Lee la carta y bebe si se aplica a ti. Perfecto para romper el hielo.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-yellow-100 via-orange-100 to-red-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-yellow-800 mb-2\">🥂 Drink If...</h2><p class=\"text-base text-gray-700\">Lee una tarjeta y bebe si te identificas. Reglas sencillas que garantizan risas y rompen el hielo de inmediato.</p><p class=\"text-sm text-gray-500 mt-2\">🍻 Genial para empezar la fiesta.</p></div>"
     },
     "resurrectionFest": {
       "title": "Resurrection Fest",
-      "description": "Preguntas y retos sobre el festival y el metal para celebrar el Resurrection Fest."
+      "description": "Preguntas y retos sobre el festival y el metal para celebrar el Resurrection Fest.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-gray-100 via-red-100 to-gray-200 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-red-800 mb-2\">🤘 Modo Resurrection Fest</h2><p class=\"text-base text-gray-700\">Vibras metaleras y retos inspirados en el famoso festival. Rockea y bebe con otros amantes del metal.</p><p class=\"text-sm text-gray-500 mt-2\">🎸 Disponible en fechas del festival.</p></div>"
     },
     "sanJuan": {
       "title": "San Juan",
-      "description": "Retos y preguntas para celebrar la Noche de San Juan."
+      "description": "Retos y preguntas para celebrar la Noche de San Juan.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-yellow-100 via-pink-100 to-purple-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-purple-800 mb-2\">🔥 Juego de Tragos para la Noche de San Juan</h2><p class=\"text-base text-gray-700\">Celebra la <strong>Noche de San Juan</strong> como nunca con <span class=\"font-semibold\">retos salvajes</span>, <span class=\"font-semibold\">preguntas atrevidas</span> y <span class=\"font-semibold\">mucho fuego y diversión</span>. Nuestra app <em>Tragos Locos</em> te trae el mejor juego para beber en la playa, frente a la hoguera o donde tú quieras. Ideal para <strong>romper el hielo</strong>, <strong>crear recuerdos épicos</strong> y vivir la noche más mágica del año con tus amigos.</p><p class=\"text-sm text-gray-500 mt-2\">🌙 Compatible con móviles. Perfecto para fiestas en San Juan 2025.</p></div>"
     },
     "duel": {
       "title": "Duelos",
-      "description": "Enfrentamientos 1v1 donde el perdedor bebe."
+      "description": "Enfrentamientos 1v1 donde el perdedor bebe.",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-purple-100 via-indigo-100 to-red-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-purple-800 mb-2\">⚔️ Modo Duelos</h2><p class=\"text-base text-gray-700\">Enfréntate en duelos uno contra uno con desafíos rápidos. El ganador presume, el perdedor bebe. Duelos intensos para mantener la tensión.</p><p class=\"text-sm text-gray-500 mt-2\">🏅 Perfecto cuando quieres competencia directa.</p></div>"
     },
     "cascade": {
       "title": "Cascada de Bebida",
-      "description": "Una acción desencadena otra en cadena. ¡No la rompas!"
+      "description": "Una acción desencadena otra en cadena. ¡No la rompas!",
+      "seo_html": "<div class=\"p-4 bg-gradient-to-br from-blue-100 via-cyan-100 to-teal-100 rounded-2xl shadow-md\"><h2 class=\"text-2xl font-bold text-blue-800 mb-2\">💧 Cascada de Bebida</h2><p class=\"text-base text-gray-700\">Cada acción desencadena la siguiente en una reacción en cadena. Mantén el ritmo y ve quién aguanta más.</p><p class=\"text-sm text-gray-500 mt-2\">🌊 Diversión para grupos amantes del ritmo.</p></div>"
     }
   },
   "blog": {

--- a/src/routes/(landing)/modes/[mode]/+page.svelte
+++ b/src/routes/(landing)/modes/[mode]/+page.svelte
@@ -118,6 +118,7 @@ import '$lib/Shuffle';
       <img src={mode.icon} alt="icono" class="w-24 h-24 mx-auto mb-4" />
       <h1 class="text-3xl font-bold mb-2">{$_(`modes.${modeKey}.title`)}</h1>
       <p class="text-gray-700">{$_(`modes.${modeKey}.description`)}</p>
+      <div class="mt-2">{@html $_(`modes.${modeKey}.seo_html`)}</div>
     </header>
 
     <section class="grid grid-cols-2 md:grid-cols-4 gap-4 text-center my-8 mb-24">


### PR DESCRIPTION
## Summary
- include `seo_html` for each mode in `en.json` and `es.json`
- render `seo_html` snippet on each mode landing page
- expand the snippets with richer Tailwind-styled HTML

## Testing
- `npm run validate` *(fails: svelte-check found 35 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684ff894fab0832fa0f370c30861d84e