### PR TITLE
Improve landing page h1 keywords

### DIFF
--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -75,7 +75,7 @@
   },
   "landing": {
     "title": "Tragos Locos",
-    "slogan": "Liven up your party, unleash the fun!",
+    "slogan": "Tragos Locos: the best drinking game for parties",
     "description": "Tired of the same old party games? Looking to spice up your social gatherings? Look no further! Tragos locos is designed to take your parties to new heights.",
     "question_counts": {
       "title": "We have a lot of questions",

--- a/src/lib/locales/es.json
+++ b/src/lib/locales/es.json
@@ -169,7 +169,7 @@
   },
   "landing": {
     "title": "Tragos Locos",
-    "slogan": "Vive la fiesta, desafía la vida!",
+    "slogan": "Tragos Locos: el mejor juego de bebidas para fiestas",
     "description": "Cansado de los mismos juegos de fiesta? ¿Buscas darle sabor a tus reuniones sociales? ¡No busques más! Tragos locos está diseñado para llevar tus fiestas a nuevas alturas.",
     "question_counts": {
       "title": "Tenemos un montón de preguntas",


### PR DESCRIPTION
## Summary
- update the landing headline translation for ES
- update the landing headline translation for EN

## Testing
- `npm run validate` *(fails: svelte-check found 35 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ffc284cac832fb527746b1d418839