### PR TITLE
Fix canonical URL in BlogPost component

### DIFF
--- a/src/lib/components/BlogPost.svelte
+++ b/src/lib/components/BlogPost.svelte
@@ -20,7 +20,7 @@
 
     let showDisqus = false;
 
-    const url = "https://tragps-locos.serviitmo.net/blog/" + lang + '/' + seoTitle;
+    const url = "https://tragos-locos.servitimo.net/blog/" + lang + '/' + seoTitle;
     const schema = {
         "@context": "https://schema.org",
         "@type": "BlogPosting",


### PR DESCRIPTION
## Summary
- fix domain used for canonical URL and OG tags in `BlogPost.svelte`

## Testing
- `npm run validate` *(fails: svelte-check found 38 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6850028b29fc832fbd2642f5bf18dd49