### PR TITLE
Add alt texts for icons & screenshots

### DIFF
--- a/src/lib/components/Splash.svelte
+++ b/src/lib/components/Splash.svelte
@@ -20,7 +20,7 @@
 
 
 <div out:fade class="absolute flex h-screen w-screen items-center justify-center bg-[#794fea]" class:in-circle-hesitate={!exitAnimation}>
-    <img src={logo} width="200px" alt="">
+    <img src={logo} width="200px" alt="Tragos Locos logo">
 </div>
 
 <style>

--- a/src/lib/components/pages/Splash.svelte
+++ b/src/lib/components/pages/Splash.svelte
@@ -12,7 +12,7 @@
 <PageContainer>
     <div class="h-full w-full bg-gradient-to-b from-[#794fea] via-white via-[60px] to-white">
         <div class="in-circle-hesitate absolute flex h-screen w-screen animate-circle-in-hesitate items-center justify-center bg-[#794fea]">
-            <img src={logo} width="200px" alt="">
+            <img src={logo} width="200px" alt="Tragos Locos logo">
         </div>
     </div>
 </PageContainer>

--- a/src/routes/(app)/+page.svelte.old
+++ b/src/routes/(app)/+page.svelte.old
@@ -11,7 +11,7 @@
 
     onMount(async () => {
         container.classList.add('bg-[#794fea]', 'animate-circle-in-hesitate', 'flex', 'flex-col', 'items-center', 'justify-center', 'h-dvh', 'w-screen');
-        container.innerHTML = `<img src="/AppImages/ios/128.png" width="200px" alt="" class="absolute top-1/2 -translate-y-1/2">`;
+        container.innerHTML = `<img src="/AppImages/ios/128.png" width="200px" alt="Tragos Locos logo" class="absolute top-1/2 -translate-y-1/2">`;
         await new Promise((resolve) => setTimeout(resolve, 4000));
         container.querySelector('img')?.classList.add('animate-fade-out', 'duration-500', 'relative');
         await new Promise((resolve) => setTimeout(resolve, 500 + 200));

--- a/src/routes/(app)/explore-modes/+page.svelte
+++ b/src/routes/(app)/explore-modes/+page.svelte
@@ -113,7 +113,7 @@
                             <!-- Icono con efecto de brillo -->
                             <div class="flex items-center justify-center w-20 h-20 rounded-2xl bg-white/15 mb-4 group-hover:scale-110 group-hover:bg-white/25 transition-all duration-500 shadow-lg relative overflow-hidden">
                                 <div class="absolute inset-0 opacity-0 group-hover:opacity-30 bg-gradient-to-r from-transparent via-white/80 to-transparent -translate-x-full group-hover:translate-x-full transition-all duration-1500 ease-in-out"></div>
-                                <img src={mode.icon} alt="" class="w-12 h-12" />
+                                <img src={mode.icon} alt={$_(`modes.${modeKey}.title`)} class="w-12 h-12" />
                             </div>
                             
                             <!-- Contenido centrado con mejor espaciado -->

--- a/src/routes/(app)/intro/+page.svelte
+++ b/src/routes/(app)/intro/+page.svelte
@@ -12,7 +12,7 @@
 <PageContainer>
     <div class="h-full w-full bg-gradient-to-b from-[#794fea] via-white via-[60px] to-white">
         <div class="in-circle-hesitate absolute flex h-screen w-screen animate-circle-in-hesitate items-center justify-center bg-[#794fea]">
-            <img src={logo} width="200px" alt="">
+            <img src={logo} width="200px" alt="Tragos Locos logo">
         </div>
     </div>
 </PageContainer>

--- a/src/routes/(app)/select-mode/+page.svelte
+++ b/src/routes/(app)/select-mode/+page.svelte
@@ -74,7 +74,7 @@
                     data-umami-event-mode="{modeKey}"
                 >
                     <div class="flex aspect-square h-[90px] w-[90px] items-center justify-center rounded-full bg-white bg-opacity-10 p-2">
-                        <img in:fly|global={{ x: index % 2 === 0 ? -200 : 200, duration: 300, delay: (index * 300) + 150 }}  src={mode.icon} alt="" class="h-full w-full animate-rubber-band" />
+                        <img in:fly|global={{ x: index % 2 === 0 ? -200 : 200, duration: 300, delay: (index * 300) + 150 }}  src={mode.icon} alt={$_(`modes.${modeKey}.title`)} class="h-full w-full animate-rubber-band" />
                     </div>
                     <div class="flex w-full flex-col justify-center">
                         <div class="text-3xl">{$_(`modes.${modeKey}.title`)}</div>

--- a/src/routes/(landing)/+page.svelte
+++ b/src/routes/(landing)/+page.svelte
@@ -106,7 +106,7 @@
                 </div>
                 <div class="flex justify-center items-center my-8">
                     <IphoneMockup>
-                        <img src="/screenshot-3.png" alt="" width="320" height="640" style="box-shadow: 10px 10px 5px 12px rgb(209, 218, 218)" class="rounded rounded-xl border border-4 border-black">
+                        <img src="/screenshot-3.png" alt="Tragos Locos screenshot" width="320" height="640" style="box-shadow: 10px 10px 5px 12px rgb(209, 218, 218)" class="rounded rounded-xl border border-4 border-black">
                     </IphoneMockup>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add alt text to main splash screens
- add alt text to screenshot on landing page
- add alt text for icons in select mode and explore modes
- update old intro/splash components

## Testing
- `npm run validate` *(fails: svelte-check found 38 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6850029cdca4832fbbdeb607a98c63f3