### PR TITLE
Add custom 404 route

### DIFF
--- a/src/routes/[...404]/+page.svelte
+++ b/src/routes/[...404]/+page.svelte
@@ -1,0 +1,20 @@
+<script>
+  import Footer from '$lib/components/Footer.svelte';
+</script>
+
+<svelte:head>
+  <title>Página no encontrada | Tragos Locos</title>
+</svelte:head>
+
+<div class="min-h-screen flex flex-col justify-center items-center text-center space-y-6 py-16">
+  <h1 class="text-6xl font-bold text-purple-700">404</h1>
+  <p class="text-xl">Ups! No encontramos lo que buscas.</p>
+  <nav class="space-x-4">
+    <a href="/" class="text-primary-600 underline">Inicio</a>
+    <a href="/sobre-la-app" class="text-primary-600 underline">Sobre la App</a>
+    <a href="/blog" class="text-primary-600 underline">Blog</a>
+    <a href="/modes" class="text-primary-600 underline">Modos</a>
+  </nav>
+</div>
+
+<Footer />


### PR DESCRIPTION
## Summary
- create catch-all 404 page with navigation links

## Testing
- `npm run build:app` *(fails: ParseError in PostContent.svelte)*

------
https://chatgpt.com/codex/tasks/task_e_685002bbe144832fb10826aa0c55283c