### PR TITLE
Add canonical and meta tags to beta page

### DIFF
--- a/src/routes/(landing)/join-beta-test/+page.svelte
+++ b/src/routes/(landing)/join-beta-test/+page.svelte
@@ -12,6 +12,7 @@
 <svelte:head>
     <title>Únete al Programa de Testers</title>
     <meta name="description" content="Sé de los primeros en probar nuestra aplicación y ayúdanos a mejorar.">
+    <link rel="canonical" href="https://tragos-locos.servitimo.net/join-beta-test/" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
@@ -19,6 +20,7 @@
     <meta property="og:title" content="Únete al Programa de Testers">
     <meta property="og:description" content="Sé de los primeros en probar nuestra aplicación y ayúdanos a mejorar.">
     <meta property="og:image" content="https://tragoslocos.com/og-image.png">
+    <meta property="og:site_name" content="Tragos Locos">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
@@ -26,6 +28,7 @@
     <meta property="twitter:title" content="Únete al Programa de Testers">
     <meta property="twitter:description" content="Sé de los primeros en probar nuestra aplicación y ayúdanos a mejorar.">
     <meta property="twitter:image" content="https://tragoslocos.com/og-image.png">
+    <meta name="twitter:site" content="@tu_cuenta">
 
 </svelte:head>
 


### PR DESCRIPTION
## Summary
- add canonical link, `og:site_name` and `twitter:site` meta tags on join-beta-test page

## Testing
- `npm run validate` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_6850053aac54832f8a29c09f97e1a2f4