### PR TITLE
Enable card casting via Web Presentation API

### DIFF
--- a/src/routes/(app)/cast/+page.svelte
+++ b/src/routes/(app)/cast/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+
+let questions: any[] = [];
+let currentIndex = 0;
+let locale = 'en';
+
+onMount(() => {
+    questions = JSON.parse(localStorage.getItem('castQuestions') || '[]');
+    locale = localStorage.getItem('castLocale') || 'en';
+    const channel = new BroadcastChannel('cast');
+    channel.onmessage = (event) => {
+        const { type, index } = event.data || {};
+        if (typeof index === 'number') {
+            currentIndex = index;
+        }
+    };
+});
+</script>
+
+{#if questions.length === 0}
+<div class="flex h-screen items-center justify-center">
+    <p class="text-2xl">Waiting for game...</p>
+</div>
+{:else}
+<div class="flex h-screen items-center justify-center p-4 text-center">
+    <span class="text-5xl font-medium" data-testid="cast-question">{@html questions[currentIndex]?.locales?.[locale] || questions[currentIndex]?.locales?.en}</span>
+</div>
+{/if}


### PR DESCRIPTION
## Summary
- add cast page for remote display
- save deck & locale for casting
- implement startCasting and wire the button

## Testing
- `npm run validate` *(fails: svelte-check found 37 errors and 25 warnings)*
- `npm run build:app`

------
https://chatgpt.com/codex/tasks/task_e_68500ae19174832fbae49caa2ec33875