### PR TITLE
Add new goose board mode using Phaser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@sentry/capacitor": "^1.0.1",
         "@types/umami": "^2.10.0",
         "@use-gesture/vanilla": "^10.3.1",
+        "phaser": "^3.90.0",
         "schema-dts": "^1.1.5",
         "svelte-i18n": "^4.0.1",
         "tailwindcss-safe-area": "^0.6.0",
@@ -4417,6 +4418,12 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -6241,6 +6248,15 @@
         "@types/estree": "^1.0.0",
         "estree-walker": "^3.0.0",
         "is-reference": "^3.0.0"
+      }
+    },
+    "node_modules/phaser": {
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.90.0.tgz",
+      "integrity": "sha512-/cziz/5ZIn02uDkC9RzN8VF9x3Gs3XdFFf9nkiMEQT3p7hQlWuyjy4QWosU802qqno2YSLn2BfqwOKLv/sSVfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@sentry/capacitor": "^1.0.1",
     "@types/umami": "^2.10.0",
     "@use-gesture/vanilla": "^10.3.1",
+    "phaser": "^3.90.0",
     "schema-dts": "^1.1.5",
     "svelte-i18n": "^4.0.1",
     "tailwindcss-safe-area": "^0.6.0",

--- a/src/lib/components/GooseBoard.svelte
+++ b/src/lib/components/GooseBoard.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+import { onMount } from 'svelte';
+let Phaser: any;
+import { page } from '$app/stores';
+import { modes } from '$lib/modes';
+import { questions } from '$lib/questions';
+import { getLocale } from '$lib/locales';
+
+let container: HTMLDivElement;
+let phaserGame: any;
+let activeQuestion = '';
+
+const mode = $page.params.mode as string;
+
+function next() {
+    const scene = phaserGame?.scene.getScene('main') as any;
+    scene?.nextTile();
+}
+
+function createScene(cards: any[], locale: string) {
+    return new Phaser.Class({
+        Extends: Phaser.Scene,
+        initialize: function MainScene() { Phaser.Scene.call(this, { key: 'main' }); },
+        preload() {},
+        create() {
+            const cols = 8;
+            const tileSize = 120;
+            const margin = 20;
+            const rows = Math.ceil(cards.length / cols);
+            this.tiles = [];
+            let index = 0;
+            for (let y = 0; y < rows; y++) {
+                for (let x = 0; x < cols && index < cards.length; x++) {
+                    const posX = (y % 2 === 0) ? x : cols - 1 - x;
+                    const rect = this.add.rectangle(posX * (tileSize + margin), y * (tileSize + margin), tileSize, tileSize, 0xffffff).setOrigin(0);
+                    const txt = cards[index].locales[locale] || cards[index].locales['en'] || Object.values(cards[index].locales || {})[0];
+                    this.add.text(rect.x + 5, rect.y + 5, txt, { fontSize: '14px', color: '#000', wordWrap: { width: tileSize - 10 } });
+                    this.tiles.push(rect);
+                    index++;
+                }
+            }
+            this.token = this.add.circle(this.tiles[0].x + tileSize / 2, this.tiles[0].y + tileSize / 2, 10, 0xff0000);
+            this.current = 0;
+            this.cameras.main.setZoom(2);
+            this.cameras.main.startFollow(this.token, true, 0.1, 0.1);
+            activeQuestion = cards[0].locales[locale] || cards[0].locales['en'] || Object.values(cards[0].locales || {})[0];
+        },
+        nextTile() {
+            if (this.current + 1 >= this.tiles.length) return;
+            this.current++;
+            const tile = this.tiles[this.current];
+            this.tweens.add({ targets: this.token, x: tile.x + 60, y: tile.y + 60, duration: 500 });
+            activeQuestion = cards[this.current].locales[locale] || cards[this.current].locales['en'] || Object.values(cards[this.current].locales || {})[0];
+        }
+    });
+}
+
+onMount(async () => {
+    Phaser = (await import('phaser')).default;
+    const players = JSON.parse(sessionStorage.getItem('players') || '[]');
+    const locale = await getLocale();
+    const filteredQuestions = modes[mode].pickCards(questions, locale, players);
+    const config = {
+        type: Phaser.AUTO,
+        parent: container,
+        width: window.innerWidth,
+        height: window.innerHeight,
+        scene: createScene(filteredQuestions, locale),
+        scale: { mode: Phaser.Scale.RESIZE }
+    };
+    phaserGame = new Phaser.Game(config);
+});
+</script>
+
+<div bind:this={container} class="w-full h-full relative"></div>
+<div class="absolute bottom-5 left-0 right-0 flex justify-center">
+    <button on:click={next} class="bg-purple-600 text-white px-4 py-2 rounded-xl">Next</button>
+</div>
+<div class="absolute bottom-20 left-0 right-0 text-center px-4">
+    <p class="text-white text-lg bg-black bg-opacity-50 p-2 rounded-lg">{activeQuestion}</p>
+</div>
+
+<style>
+    :global(canvas) {
+        touch-action: none;
+    }
+</style>

--- a/src/routes/(app)/goose/[mode]/+page.server.ts
+++ b/src/routes/(app)/goose/[mode]/+page.server.ts
@@ -1,0 +1,10 @@
+import { modes } from "$lib/modes";
+import { EntryGenerator } from "./$types";
+
+export const entries: EntryGenerator = () => {
+    return Object.keys(modes).map((key) => {
+        return {
+            mode: key,
+        };
+    });
+};

--- a/src/routes/(app)/goose/[mode]/+page.svelte
+++ b/src/routes/(app)/goose/[mode]/+page.svelte
@@ -1,0 +1,18 @@
+export const prerender = false;
+export const ssr = false;
+<script lang="ts">
+import GooseBoard from '$lib/components/GooseBoard.svelte';
+import PageContainer from '$lib/components/PageContainer.svelte';
+import { onMount } from 'svelte';
+import { incrementDaysPlayed } from '$lib/UserInfo';
+
+onMount(() => {
+    incrementDaysPlayed();
+});
+</script>
+
+<PageContainer>
+    <div class="h-dvh max-h-screen min-h-dvh pb-safe relative">
+        <GooseBoard />
+    </div>
+</PageContainer>


### PR DESCRIPTION
## Summary
- add Phaser dependency
- create `GooseBoard` component with Phaser board
- implement `/goose/[mode]` route to launch GooseBoard

## Testing
- `npm run build:app`

------
https://chatgpt.com/codex/tasks/task_e_685015209734832f9e2025069c82a343