### PR TITLE
Update sitemap config

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev:vite": "vite --host --port 5001",
     "#Utilities": "Various utilities",
     "validate": "svelte-check",
-    "postbuild": "npx svelte-sitemap --domain https://tragos-locos.servitimo.net --ignore '**/play/**' --ignore '**/intro/**' --ignore '**/select-mode/**' --ignore '**/add-players/**' --ignore '**/settings/**'"
+    "postbuild": "npx svelte-sitemap --domain https://tragos-locos.servitimo.net --ignore '**/play/**' --ignore '**/intro/**' --ignore '**/select-mode/**' --ignore '**/add-players/**' --ignore '**/settings/**' --ignore '**/mode/*/info/**'"
   },
   "devDependencies": {
     "@capacitor/cli": "^6.0.0",


### PR DESCRIPTION
## Summary
- keep /modes/[mode] in sitemap
- ignore /mode/*/info pages during sitemap generation

## Testing
- `npm run validate` *(fails: 35 errors, 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6853ba52e87c832fb6cba89c5df470e5