### PR TITLE
Fix join-beta meta URLs

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,3 @@
 export const PUBLIC_UMAMI_WEBSITE_ID = "2d4d3083-69a9-44c7-b25d-a4015eedffdb"
 export const PUBLIC_SENTRY_DSN = "https://9b6988e18c8e96fc6ef97d1e57f1907f@o4504724952842240.ingest.us.sentry.io/4508282210287616";
+export const SITE_URL = "https://tragos-locos.servitimo.net";

--- a/src/routes/(landing)/join-beta-test/+page.svelte
+++ b/src/routes/(landing)/join-beta-test/+page.svelte
@@ -1,6 +1,7 @@
 
 <script>
     import { onMount } from "svelte";
+    import { SITE_URL } from "$lib/config";
 
     onMount(() => {
         if (window.umami) {
@@ -12,22 +13,22 @@
 <svelte:head>
     <title>Únete al Programa de Testers</title>
     <meta name="description" content="Sé de los primeros en probar nuestra aplicación y ayúdanos a mejorar.">
-    <link rel="canonical" href="https://tragos-locos.servitimo.net/join-beta-test/" />
+    <link rel="canonical" href="{SITE_URL}/join-beta-test/" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://tragoslocos.com/join-beta-test">
+    <meta property="og:url" content="{SITE_URL}/join-beta-test/">
     <meta property="og:title" content="Únete al Programa de Testers">
     <meta property="og:description" content="Sé de los primeros en probar nuestra aplicación y ayúdanos a mejorar.">
-    <meta property="og:image" content="https://tragoslocos.com/og-image.png">
+    <meta property="og:image" content="{SITE_URL}/og-image.png">
     <meta property="og:site_name" content="Tragos Locos">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://tragoslocos.com/join-beta-test">
+    <meta property="twitter:url" content="{SITE_URL}/join-beta-test/">
     <meta property="twitter:title" content="Únete al Programa de Testers">
     <meta property="twitter:description" content="Sé de los primeros en probar nuestra aplicación y ayúdanos a mejorar.">
-    <meta property="twitter:image" content="https://tragoslocos.com/og-image.png">
+    <meta property="twitter:image" content="{SITE_URL}/og-image.png">
     <meta name="twitter:site" content="@tu_cuenta">
 
 </svelte:head>


### PR DESCRIPTION
## Summary
- use a shared SITE_URL constant
- point join-beta-test meta tags to the canonical domain

## Testing
- `npm run validate` *(fails: svelte-check found 35 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6853bc20df60832f821cf4946a63f3a3