### PR TITLE
Add hreflang links for landing pages

### DIFF
--- a/src/lib/locales/index.ts
+++ b/src/lib/locales/index.ts
@@ -4,6 +4,8 @@ import en from './en.json';
 
 export { _ } from 'svelte-i18n';
 
+export const locales = ['en', 'es'];
+
 addMessages('en', en);
 addMessages('es', es);
 

--- a/src/routes/(landing)/+page.svelte
+++ b/src/routes/(landing)/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { _, getLocale } from "$lib/locales";
+    import { _, getLocale, locales } from "$lib/locales";
     import logo from '$lib/images/AppImages/ios/256.png';
     import playstoreBadge from '$lib/images/InstallBanners/PLAYSTORE-black-en.svg';
     import AppstoreBadge from '$lib/images/InstallBanners/APPSTORE-white-en.svg';
@@ -38,6 +38,9 @@
     <meta name="description" content={$_('landing.description')} />
     <meta name="keywords" content="Tragos Locos, drinking game, party game, fun app, juegos para beber" />
     <link rel="canonical" href="https://tragos-locos.servitimo.net" />
+    {#each locales as lang}
+        <link rel="alternate" hreflang={lang} href="https://tragos-locos.servitimo.net/?locale={lang}" />
+    {/each}
 
     <meta property="og:title" content={$_('landing.slogan')} />
     <meta property="og:description" content={$_('landing.description')} />

--- a/src/routes/(landing)/join-beta-test/+page.svelte
+++ b/src/routes/(landing)/join-beta-test/+page.svelte
@@ -1,6 +1,7 @@
 
-<script>
+<script lang="ts">
     import { onMount } from "svelte";
+    import { locales } from "$lib/locales";
 
     onMount(() => {
         if (window.umami) {
@@ -13,6 +14,9 @@
     <title>Únete al Programa de Testers</title>
     <meta name="description" content="Sé de los primeros en probar nuestra aplicación y ayúdanos a mejorar.">
     <link rel="canonical" href="https://tragos-locos.servitimo.net/join-beta-test/" />
+    {#each locales as lang}
+        <link rel="alternate" hreflang={lang} href="https://tragos-locos.servitimo.net/join-beta-test/?locale={lang}" />
+    {/each}
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">

--- a/src/routes/(landing)/modes/+page.svelte
+++ b/src/routes/(landing)/modes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { _ } from '$lib/locales';
+  import { _, locales } from '$lib/locales';
   import { modes } from '$lib/modes';
   import Footer from '$lib/components/Footer.svelte';
   import { SchemaGenerator } from '$lib/utils/SchemaGenerator';
@@ -17,6 +17,9 @@
   <title>{$_('modes_page.title')} | Tragos Locos</title>
   <meta name="description" content={$_('modes_page.description')} />
   <link rel="canonical" href="https://tragos-locos.servitimo.net/modes/" />
+  {#each locales as lang}
+    <link rel="alternate" hreflang={lang} href="https://tragos-locos.servitimo.net/modes/?locale={lang}" />
+  {/each}
   {@html `<script type="application/ld+json">${JSON.stringify(
     SchemaGenerator.getBreadcrumbs([
       { name: 'Tragos Locos', url: 'https://tragos-locos.servitimo.net/' },

--- a/src/routes/(landing)/modes/[mode]/+page.svelte
+++ b/src/routes/(landing)/modes/[mode]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from '$app/stores';
   import { type Mode, modes } from '$lib/modes';
-import { _, getLocale } from '$lib/locales';
+import { _, getLocale, locales } from '$lib/locales';
 import { onMount } from 'svelte';
 import RelatedModes from '$lib/components/RelatedModes.svelte';
 import Footer from '$lib/components/Footer.svelte';
@@ -91,6 +91,9 @@ import '$lib/Shuffle';
     <title>{$_(`modes.${modeKey}.title`)} | Tragos Locos</title>
     <meta name="description" content={$_(`modes.${modeKey}.description`)} />
     <link rel="canonical" href={`https://tragos-locos.servitimo.net/modes/${modeKey}/`} />
+    {#each locales as lang}
+      <link rel="alternate" hreflang={lang} href={`https://tragos-locos.servitimo.net/modes/${modeKey}/?locale=${lang}`} />
+    {/each}
     {@html `<script type="application/ld+json">${JSON.stringify(
       SchemaGenerator.getBreadcrumbs([
         { name: 'Tragos Locos', url: 'https://tragos-locos.servitimo.net/' },

--- a/src/routes/(landing)/sobre-la-app/+page.svelte
+++ b/src/routes/(landing)/sobre-la-app/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import Footer from '$lib/components/Footer.svelte';
+  import { locales } from '$lib/locales';
   
   // Palabras clave y frases importantes para SEO
   const seoKeywords = [
@@ -28,6 +29,9 @@
     <meta name="description" content="Descubre por qué Tragos Locos es la aplicación de juegos para beber más popular. Con +1000 preguntas y retos, modos temáticos y diseño intuitivo. ¡Descárgala gratis!" />
     <meta name="keywords" content="tragos locos, juegos para beber, party game, app de fiestas, juegos con alcohol, preguntas atrevidas, retos de fiesta, juegos de grupo, aplicación para reuniones" />
     <link rel="canonical" href="https://tragos-locos.servitimo.net/sobre-la-app/" />
+    {#each locales as lang}
+      <link rel="alternate" hreflang={lang} href="https://tragos-locos.servitimo.net/sobre-la-app/?locale={lang}" />
+    {/each}
     
     <!-- Meta tags para Open Graph (Facebook, WhatsApp) -->
     <meta property="og:title" content="Tragos Locos: La Mejor App de Juegos para Fiestas" />


### PR DESCRIPTION
## Summary
- export list of locales from `$lib/locales`
- generate `<link rel="alternate" hreflang>` for each locale on landing pages

## Testing
- `npm run validate` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853bc374f7c832fa9bb90306e56e670