### PR TITLE
Fix canonical URLs to always end with slash

### DIFF
--- a/src/lib/components/BlogPost.svelte
+++ b/src/lib/components/BlogPost.svelte
@@ -20,7 +20,7 @@
 
     let showDisqus = false;
 
-    const url = "https://tragos-locos.servitimo.net/blog/" + lang + '/' + seoTitle;
+    const url = "https://tragos-locos.servitimo.net/blog/" + lang + '/' + seoTitle + '/';
     const schema = {
         "@context": "https://schema.org",
         "@type": "BlogPosting",

--- a/src/routes/(blog)/blog/[locale]/+page.svelte
+++ b/src/routes/(blog)/blog/[locale]/+page.svelte
@@ -11,7 +11,7 @@
 </script>
 
 <svelte:head>
-    {canonicalUrl = 'https://tragos-locos.servitimo.net/blog/' + locale, ''}
+    {canonicalUrl = 'https://tragos-locos.servitimo.net/blog/' + locale + '/', ''}
     <title>Blog - Tragos Locos</title>
     <meta name="description" content={$_('blog.description')} />
 

--- a/src/routes/(landing)/+page.svelte
+++ b/src/routes/(landing)/+page.svelte
@@ -37,7 +37,7 @@
     <title>{$_('landing.title')} | {$_('landing.slogan')}</title>
     <meta name="description" content={$_('landing.description')} />
     <meta name="keywords" content="Tragos Locos, drinking game, party game, fun app, juegos para beber" />
-    <link rel="canonical" href="https://tragos-locos.servitimo.net" />
+    <link rel="canonical" href="https://tragos-locos.servitimo.net/" />
 
     <meta property="og:title" content={$_('landing.slogan')} />
     <meta property="og:description" content={$_('landing.description')} />


### PR DESCRIPTION
## Summary
- ensure canonical URLs in BlogPost and blog index pages include a trailing slash
- update canonical URL of the landing page to have a trailing slash

## Testing
- `npm run --silent validate` *(fails: svelte-check found 35 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6853bcea705c832fa0e14dcd74624952