### PR TITLE
Add hreflang tags

### DIFF
--- a/src/routes/(landing)/+page.svelte
+++ b/src/routes/(landing)/+page.svelte
@@ -38,6 +38,10 @@
     <meta name="description" content={$_('landing.description')} />
     <meta name="keywords" content="Tragos Locos, drinking game, party game, fun app, juegos para beber" />
     <link rel="canonical" href="https://tragos-locos.servitimo.net/" />
+    <link rel="alternate" hreflang="es" href="https://tragos-locos.servitimo.net/?locale=es" />
+    <link rel="alternate" hreflang="en" href="https://tragos-locos.servitimo.net/?locale=en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="en" />
 
     <meta property="og:title" content={$_('landing.slogan')} />
     <meta property="og:description" content={$_('landing.description')} />

--- a/src/routes/(landing)/join-beta-test/+page.svelte
+++ b/src/routes/(landing)/join-beta-test/+page.svelte
@@ -14,6 +14,10 @@
     <title>Únete al Programa de Testers</title>
     <meta name="description" content="Sé de los primeros en probar nuestra aplicación y ayúdanos a mejorar.">
     <link rel="canonical" href="{SITE_URL}/join-beta-test/" />
+    <link rel="alternate" hreflang="es" href="{SITE_URL}/join-beta-test/?locale=es" />
+    <link rel="alternate" hreflang="en" href="{SITE_URL}/join-beta-test/?locale=en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="en" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">

--- a/src/routes/(landing)/modes/+page.svelte
+++ b/src/routes/(landing)/modes/+page.svelte
@@ -17,6 +17,10 @@
   <title>{$_('modes_page.title')} | Tragos Locos</title>
   <meta name="description" content={$_('modes_page.description')} />
   <link rel="canonical" href="https://tragos-locos.servitimo.net/modes/" />
+  <link rel="alternate" hreflang="es" href="https://tragos-locos.servitimo.net/modes/?locale=es" />
+  <link rel="alternate" hreflang="en" href="https://tragos-locos.servitimo.net/modes/?locale=en" />
+  <meta property="og:locale:alternate" content="es" />
+  <meta property="og:locale:alternate" content="en" />
   {@html `<script type="application/ld+json">${JSON.stringify(
     SchemaGenerator.getBreadcrumbs([
       { name: 'Tragos Locos', url: 'https://tragos-locos.servitimo.net/' },

--- a/src/routes/(landing)/modes/[mode]/+page.svelte
+++ b/src/routes/(landing)/modes/[mode]/+page.svelte
@@ -91,6 +91,10 @@ import '$lib/Shuffle';
     <title>{$_(`modes.${modeKey}.title`)} | Tragos Locos</title>
     <meta name="description" content={$_(`modes.${modeKey}.description`)} />
     <link rel="canonical" href={`https://tragos-locos.servitimo.net/modes/${modeKey}/`} />
+    <link rel="alternate" hreflang="es" href={`https://tragos-locos.servitimo.net/modes/${modeKey}/?locale=es`} />
+    <link rel="alternate" hreflang="en" href={`https://tragos-locos.servitimo.net/modes/${modeKey}/?locale=en`} />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="en" />
     {@html `<script type="application/ld+json">${JSON.stringify(
       SchemaGenerator.getBreadcrumbs([
         { name: 'Tragos Locos', url: 'https://tragos-locos.servitimo.net/' },

--- a/src/routes/(landing)/sobre-la-app/+page.svelte
+++ b/src/routes/(landing)/sobre-la-app/+page.svelte
@@ -28,6 +28,10 @@
     <meta name="description" content="Descubre por qué Tragos Locos es la aplicación de juegos para beber más popular. Con +1000 preguntas y retos, modos temáticos y diseño intuitivo. ¡Descárgala gratis!" />
     <meta name="keywords" content="tragos locos, juegos para beber, party game, app de fiestas, juegos con alcohol, preguntas atrevidas, retos de fiesta, juegos de grupo, aplicación para reuniones" />
     <link rel="canonical" href="https://tragos-locos.servitimo.net/sobre-la-app/" />
+    <link rel="alternate" hreflang="es" href="https://tragos-locos.servitimo.net/sobre-la-app/?locale=es" />
+    <link rel="alternate" hreflang="en" href="https://tragos-locos.servitimo.net/sobre-la-app/?locale=en" />
+    <meta property="og:locale:alternate" content="es" />
+    <meta property="og:locale:alternate" content="en" />
     
     <!-- Meta tags para Open Graph (Facebook, WhatsApp) -->
     <meta property="og:title" content="Tragos Locos: La Mejor App de Juegos para Fiestas" />


### PR DESCRIPTION
## Summary
- add hreflang alternates to landing pages
- include `og:locale:alternate` meta tags

## Testing
- `npm run validate` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853bf25fe3c832fa940674a351f8665