### PR TITLE
Refactor landing metadata to use SITE_URL

### DIFF
--- a/src/routes/(landing)/+page.svelte
+++ b/src/routes/(landing)/+page.svelte
@@ -11,6 +11,7 @@
     import Steps from '$lib/components/landingBlocks/Steps.svelte';
     import Footer from '$lib/components/Footer.svelte';
     import { onMount } from "svelte";
+    import { SITE_URL } from "$lib/config";
     import Quiz from "$lib/components/landingBlocks/Quiz.svelte";
     import Laughts from "$lib/components/landingBlocks/Laughts.svelte";
     import Faqs from "$lib/components/landingBlocks/Faqs.svelte";
@@ -37,19 +38,19 @@
     <title>{$_('landing.title')} | {$_('landing.slogan')}</title>
     <meta name="description" content={$_('landing.description')} />
     <meta name="keywords" content="Tragos Locos, drinking game, party game, fun app, juegos para beber" />
-    <link rel="canonical" href="https://tragos-locos.servitimo.net/" />
+    <link rel="canonical" href={`${SITE_URL}/`} />
 
     <meta property="og:title" content={$_('landing.slogan')} />
     <meta property="og:description" content={$_('landing.description')} />
-    <meta property="og:image" content="https://tragos-locos.servitimo.net/og-image.png" />
-    <meta property="og:url" content="https://tragos-locos.servitimo.net" />
+    <meta property="og:image" content={`${SITE_URL}/og-image.png`} />
+    <meta property="og:url" content={SITE_URL} />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Tragos Locos" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={$_('landing.slogan')} />
     <meta name="twitter:description" content={$_('landing.description')} />
-    <meta name="twitter:image" content="https://tragos-locos.servitimo.net/og-image.png" />
+    <meta name="twitter:image" content={`${SITE_URL}/og-image.png`} />
 
     <script type="application/ld+json">
         {

--- a/src/routes/(landing)/join-beta-test/+page.svelte
+++ b/src/routes/(landing)/join-beta-test/+page.svelte
@@ -13,22 +13,22 @@
 <svelte:head>
     <title>Únete al Programa de Testers</title>
     <meta name="description" content="Sé de los primeros en probar nuestra aplicación y ayúdanos a mejorar.">
-    <link rel="canonical" href="{SITE_URL}/join-beta-test/" />
+    <link rel="canonical" href={`${SITE_URL}/join-beta-test/`} />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="{SITE_URL}/join-beta-test/">
+    <meta property="og:url" content={`${SITE_URL}/join-beta-test/`}>
     <meta property="og:title" content="Únete al Programa de Testers">
     <meta property="og:description" content="Sé de los primeros en probar nuestra aplicación y ayúdanos a mejorar.">
-    <meta property="og:image" content="{SITE_URL}/og-image.png">
+    <meta property="og:image" content={`${SITE_URL}/og-image.png`}>
     <meta property="og:site_name" content="Tragos Locos">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="{SITE_URL}/join-beta-test/">
+    <meta property="twitter:url" content={`${SITE_URL}/join-beta-test/`}>
     <meta property="twitter:title" content="Únete al Programa de Testers">
     <meta property="twitter:description" content="Sé de los primeros en probar nuestra aplicación y ayúdanos a mejorar.">
-    <meta property="twitter:image" content="{SITE_URL}/og-image.png">
+    <meta property="twitter:image" content={`${SITE_URL}/og-image.png`}>
     <meta name="twitter:site" content="@tu_cuenta">
 
 </svelte:head>

--- a/src/routes/(landing)/modes/+page.svelte
+++ b/src/routes/(landing)/modes/+page.svelte
@@ -3,6 +3,7 @@
   import { modes } from '$lib/modes';
   import Footer from '$lib/components/Footer.svelte';
   import { SchemaGenerator } from '$lib/utils/SchemaGenerator';
+  import { SITE_URL } from '$lib/config';
 
   const modeEntries = Object.entries(modes).filter(([key, mode]) => mode.isPublic ?? true);
   
@@ -16,11 +17,11 @@
 <svelte:head>
   <title>{$_('modes_page.title')} | Tragos Locos</title>
   <meta name="description" content={$_('modes_page.description')} />
-  <link rel="canonical" href="https://tragos-locos.servitimo.net/modes/" />
+  <link rel="canonical" href={`${SITE_URL}/modes/`} />
   {@html `<script type="application/ld+json">${JSON.stringify(
     SchemaGenerator.getBreadcrumbs([
-      { name: 'Tragos Locos', url: 'https://tragos-locos.servitimo.net/' },
-      { name: $_('modes_page.title'), url: 'https://tragos-locos.servitimo.net/modes/' }
+      { name: 'Tragos Locos', url: `${SITE_URL}/` },
+      { name: $_('modes_page.title'), url: `${SITE_URL}/modes/` }
     ])
   )}</script>`}
 </svelte:head>

--- a/src/routes/(landing)/modes/[mode]/+page.svelte
+++ b/src/routes/(landing)/modes/[mode]/+page.svelte
@@ -8,6 +8,7 @@ import Footer from '$lib/components/Footer.svelte';
 import { SchemaGenerator } from '$lib/utils/SchemaGenerator';
 import { questions } from '$lib/questions';
 import '$lib/Shuffle';
+import { SITE_URL } from '$lib/config';
   let modeKey: string = '';
   let mode: Mode | null = null;
   let examples: string[] = [];
@@ -90,12 +91,12 @@ import '$lib/Shuffle';
   {#if mode}
     <title>{$_(`modes.${modeKey}.title`)} | Tragos Locos</title>
     <meta name="description" content={$_(`modes.${modeKey}.description`)} />
-    <link rel="canonical" href={`https://tragos-locos.servitimo.net/modes/${modeKey}/`} />
+    <link rel="canonical" href={`${SITE_URL}/modes/${modeKey}/`} />
     {@html `<script type="application/ld+json">${JSON.stringify(
       SchemaGenerator.getBreadcrumbs([
-        { name: 'Tragos Locos', url: 'https://tragos-locos.servitimo.net/' },
-        { name: $_('modes_page.title'), url: 'https://tragos-locos.servitimo.net/modes/' },
-        { name: $_(`modes.${modeKey}.title`), url: `https://tragos-locos.servitimo.net/modes/${modeKey}/` }
+        { name: 'Tragos Locos', url: `${SITE_URL}/` },
+        { name: $_('modes_page.title'), url: `${SITE_URL}/modes/` },
+        { name: $_(`modes.${modeKey}.title`), url: `${SITE_URL}/modes/${modeKey}/` }
       ])
     )}</script>`}
   {/if}

--- a/src/routes/(landing)/sobre-la-app/+page.svelte
+++ b/src/routes/(landing)/sobre-la-app/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import Footer from '$lib/components/Footer.svelte';
+  import { SITE_URL } from '$lib/config';
   
   // Palabras clave y frases importantes para SEO
   const seoKeywords = [
@@ -27,20 +28,20 @@
     <title>Tragos Locos: La Mejor App de Juegos para Beber y Animar Fiestas</title>
     <meta name="description" content="Descubre por qué Tragos Locos es la aplicación de juegos para beber más popular. Con +1000 preguntas y retos, modos temáticos y diseño intuitivo. ¡Descárgala gratis!" />
     <meta name="keywords" content="tragos locos, juegos para beber, party game, app de fiestas, juegos con alcohol, preguntas atrevidas, retos de fiesta, juegos de grupo, aplicación para reuniones" />
-    <link rel="canonical" href="https://tragos-locos.servitimo.net/sobre-la-app/" />
+    <link rel="canonical" href={`${SITE_URL}/sobre-la-app/`} />
     
     <!-- Meta tags para Open Graph (Facebook, WhatsApp) -->
     <meta property="og:title" content="Tragos Locos: La Mejor App de Juegos para Fiestas" />
     <meta property="og:description" content="La aplicación de juegos para beber #1 con +1000 preguntas y retos. Perfecta para animar cualquier reunión o fiesta. ¡Descárgala gratis!" />
-    <meta property="og:image" content="https://tragos-locos.servitimo.net/og-image.png" />
-    <meta property="og:url" content="https://tragos-locos.servitimo.net/sobre-la-app/" />
+    <meta property="og:image" content={`${SITE_URL}/og-image.png`} />
+    <meta property="og:url" content={`${SITE_URL}/sobre-la-app/`} />
     <meta property="og:type" content="website" />
     
     <!-- Meta tags para Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Tragos Locos: App #1 de Juegos para Beber" />
     <meta name="twitter:description" content="Anima tus fiestas con la mejor app de juegos para beber. +1000 preguntas, varios modos de juego y totalmente gratis." />
-    <meta name="twitter:image" content="https://tragos-locos.servitimo.net/og-image.png" />
+    <meta name="twitter:image" content={`${SITE_URL}/og-image.png`} />
 </svelte:head>
 
 <header class="flex items-center w-full bg-white justify-between py-4 px-4 shadow-sm sticky top-0 z-50">


### PR DESCRIPTION
## Summary
- import `SITE_URL` constant across landing pages
- use constant for canonical and OG URLs
- replace hardcoded domain strings

## Testing
- `npm run validate` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853bf1dd2a8832fb8b1aade026fd5a9