### PR TITLE
Update logo alt text

### DIFF
--- a/src/routes/(landing)/+page.svelte
+++ b/src/routes/(landing)/+page.svelte
@@ -67,7 +67,7 @@
     <main class="flex w-full flex-wrap justify-center gap-6 p-4 sm:flex-row-reverse md:pt-10">
         <div class="max-w-[640px] px-4">
             
-            <img src={logo} class="h-20 py-4" alt="audiostory app maker">
+            <img src={logo} class="h-20 py-4" alt="Tragos Locos logo">
             <h1 class="pt-2 text-center text-[36px] font-extrabold leading-10 md:text-start md:text-[50px] md:leading-[54px]">
                 {$_("landing.slogan")}
             </h1>


### PR DESCRIPTION
## Summary
- clarify alt text for landing page logo

## Testing
- `npm run validate` *(fails: svelte-check found 35 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6853bf41874c832fa8d608bdada63718