### PR TITLE
Add robots meta tag to landing pages

### DIFF
--- a/src/routes/(landing)/+page.svelte
+++ b/src/routes/(landing)/+page.svelte
@@ -38,6 +38,7 @@
     <meta name="description" content={$_('landing.description')} />
     <meta name="keywords" content="Tragos Locos, drinking game, party game, fun app, juegos para beber" />
     <link rel="canonical" href="https://tragos-locos.servitimo.net/" />
+    <meta name="robots" content="index,follow" />
 
     <meta property="og:title" content={$_('landing.slogan')} />
     <meta property="og:description" content={$_('landing.description')} />

--- a/src/routes/(landing)/join-beta-test/+page.svelte
+++ b/src/routes/(landing)/join-beta-test/+page.svelte
@@ -14,6 +14,7 @@
     <title>Únete al Programa de Testers</title>
     <meta name="description" content="Sé de los primeros en probar nuestra aplicación y ayúdanos a mejorar.">
     <link rel="canonical" href="{SITE_URL}/join-beta-test/" />
+    <meta name="robots" content="index,follow" />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">

--- a/src/routes/(landing)/modes/+page.svelte
+++ b/src/routes/(landing)/modes/+page.svelte
@@ -17,6 +17,7 @@
   <title>{$_('modes_page.title')} | Tragos Locos</title>
   <meta name="description" content={$_('modes_page.description')} />
   <link rel="canonical" href="https://tragos-locos.servitimo.net/modes/" />
+  <meta name="robots" content="index,follow" />
   {@html `<script type="application/ld+json">${JSON.stringify(
     SchemaGenerator.getBreadcrumbs([
       { name: 'Tragos Locos', url: 'https://tragos-locos.servitimo.net/' },

--- a/src/routes/(landing)/modes/[mode]/+page.svelte
+++ b/src/routes/(landing)/modes/[mode]/+page.svelte
@@ -91,6 +91,7 @@ import '$lib/Shuffle';
     <title>{$_(`modes.${modeKey}.title`)} | Tragos Locos</title>
     <meta name="description" content={$_(`modes.${modeKey}.description`)} />
     <link rel="canonical" href={`https://tragos-locos.servitimo.net/modes/${modeKey}/`} />
+    <meta name="robots" content="index,follow" />
     {@html `<script type="application/ld+json">${JSON.stringify(
       SchemaGenerator.getBreadcrumbs([
         { name: 'Tragos Locos', url: 'https://tragos-locos.servitimo.net/' },

--- a/src/routes/(landing)/sobre-la-app/+page.svelte
+++ b/src/routes/(landing)/sobre-la-app/+page.svelte
@@ -28,6 +28,7 @@
     <meta name="description" content="Descubre por qué Tragos Locos es la aplicación de juegos para beber más popular. Con +1000 preguntas y retos, modos temáticos y diseño intuitivo. ¡Descárgala gratis!" />
     <meta name="keywords" content="tragos locos, juegos para beber, party game, app de fiestas, juegos con alcohol, preguntas atrevidas, retos de fiesta, juegos de grupo, aplicación para reuniones" />
     <link rel="canonical" href="https://tragos-locos.servitimo.net/sobre-la-app/" />
+    <meta name="robots" content="index,follow" />
     
     <!-- Meta tags para Open Graph (Facebook, WhatsApp) -->
     <meta property="og:title" content="Tragos Locos: La Mejor App de Juegos para Fiestas" />


### PR DESCRIPTION
## Summary
- optimize search visibility for landing pages by adding `robots` meta tag

## Testing
- `npm run validate` *(fails: svelte-check found 35 errors and 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6853bf530c8c832fab140df553d6631f