### PR TITLE
Add organization and website schemas

### DIFF
--- a/src/lib/utils/SchemaGenerator.ts
+++ b/src/lib/utils/SchemaGenerator.ts
@@ -1,4 +1,11 @@
-import { BreadcrumbList, Product, Recipe, WithContext } from "schema-dts"
+import {
+    BreadcrumbList,
+    Product,
+    Recipe,
+    WithContext,
+    Organization,
+    WebSite
+} from "schema-dts"
 
 export class SchemaGenerator {
     public static getBreadcrumbs(items: {name: string, url: string}[]): WithContext<BreadcrumbList> {
@@ -132,5 +139,52 @@ export class SchemaGenerator {
         }
 
         return recipeSchema;
+    }
+
+    public static getOrganization(organization: {
+        name: string,
+        url: string,
+        logo: string,
+        sameAs?: string[]
+    }): WithContext<Organization> {
+        const organizationSchema: WithContext<Organization> = {
+            "@context": "https://schema.org",
+            "@type": "Organization",
+            name: organization.name,
+            url: organization.url,
+            logo: organization.logo
+        }
+
+        if (organization.sameAs) {
+            organizationSchema.sameAs = organization.sameAs
+        }
+
+        return organizationSchema
+    }
+
+    public static getWebSite(website: {
+        name: string,
+        url: string,
+        searchUrl?: string
+    }): WithContext<WebSite> {
+        const webSiteSchema: WithContext<WebSite> = {
+            "@context": "https://schema.org",
+            "@type": "WebSite",
+            name: website.name,
+            url: website.url
+        }
+
+        if (website.searchUrl) {
+            webSiteSchema.potentialAction = {
+                "@type": "SearchAction",
+                target: {
+                    "@type": "EntryPoint",
+                    urlTemplate: website.searchUrl
+                },
+                "query-input": "required name=search_term_string"
+            }
+        }
+
+        return webSiteSchema
     }
 }

--- a/src/routes/(landing)/+page.svelte
+++ b/src/routes/(landing)/+page.svelte
@@ -16,7 +16,20 @@
     import Faqs from "$lib/components/landingBlocks/Faqs.svelte";
     import IphoneMockup from "$lib/components/IphoneMockup.svelte";
     import FeaturedModes from "$lib/components/landingBlocks/FeaturedModes.svelte";
+    import { SchemaGenerator } from '$lib/utils/SchemaGenerator';
+    import { SITE_URL } from '$lib/config';
     
+    const organizationSchema = SchemaGenerator.getOrganization({
+        name: 'Tragos Locos',
+        url: SITE_URL,
+        logo: SITE_URL + '/og-image.png'
+    });
+
+    const websiteSchema = SchemaGenerator.getWebSite({
+        name: 'Tragos Locos',
+        url: SITE_URL
+    });
+
     let isSheetOpen = false;
 
     let locale: string | undefined;
@@ -61,6 +74,8 @@
             "description": "Tragos locos is a drinking party game app designed to elevate your social gatherings with endless fun."
         }
     </script>
+    {@html `<script type="application/ld+json">${JSON.stringify(organizationSchema)}</script>`}
+    {@html `<script type="application/ld+json">${JSON.stringify(websiteSchema)}</script>`}
 </svelte:head>
 
 <div class="bg-gray-50">


### PR DESCRIPTION
## Summary
- extend SchemaGenerator with helpers for Organization and WebSite
- reference SITE_URL in landing page script
- render Organization and WebSite schema on landing page

## Testing
- `npm run validate` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853bf5fafd0832f94c6fd3701ca2e9f