### PR TITLE
Add missing Spanish locale keys

### DIFF
--- a/src/lib/locales/es.json
+++ b/src/lib/locales/es.json
@@ -243,6 +243,7 @@
     "modes": "Modos",
     "settings": "Ajustes"
   },
+  "end_of_game": "¡Fin del juego!",
   "laughts": {
     "loading": "Cargando...",
     "laught": "¡Ríe!",
@@ -255,6 +256,9 @@
     "title": "¿Listo para comenzar a jugar?",
     "text": "Descarga la app ahora y empieza a disfrutar de los mejores juegos en grupo.",
     "action": "Descargar ahora"
+  },
+  "faqs": {
+    "title": "Preguntas frecuentes"
   },
   "modes_page": {
     "title": "Modos de Juego",


### PR DESCRIPTION
## Summary
- add `end_of_game` and `faqs.title` in `es.json`
- confirm locale files share base key structure

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build:app`

------
https://chatgpt.com/codex/tasks/task_e_6853ca314f90832f8ec594685ad2ccaf