### PR TITLE
Add CrazyGames SDK when embedded

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,22 +1,30 @@
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
 declare global {
-        namespace App {
-                // interface Error {}
-                // interface Locals {}
-                // interface PageData {}
-                // interface Platform {}
-        }
+    namespace App {
+        // interface Error {}
+        // interface Locals {}
+        // interface PageData {}
+        // interface Platform {}
+    }
 
-        interface Array<T> {
-                shuffle(): T[]
-        }
+    interface Array<T> {
+        shuffle(): T[]
+    }
 
-        interface String {
-                spintax(): string
-                bold(): string
-                underline(): string
+    interface String {
+        spintax(): string
+        bold(): string
+        underline(): string
+    }
+    
+    interface Window {
+        CrazyGames: {
+            SDK: {
+                init: () => void;
+            }
         }
+    }
 }
 
 export {};

--- a/src/lib/OriginChecker.ts
+++ b/src/lib/OriginChecker.ts
@@ -11,5 +11,12 @@ export class OriginChecker {
     static isProduction = (location: string) => {
         return !OriginChecker.isDev(location);
     }
-    
+
+    static isCrazyGames = () => {
+        if (typeof window === 'undefined' || typeof document === 'undefined') return false;
+        const isIframe = window.self !== window.top;
+        const referrer = document.referrer || '';
+        return isIframe && referrer.includes('crazygames');
+    }
+
 }

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -2,8 +2,8 @@
     import { onMount } from 'svelte';
     import { fade, fly } from 'svelte/transition';
 	import { PUBLIC_SENTRY_DSN } from '$lib/config';
-    import { OriginChecker } from '$lib/OriginChecker';
-	import { page } from '$app/stores';
+import { OriginChecker } from '$lib/OriginChecker';
+import { page } from '$app/stores';
 
 	
 
@@ -15,7 +15,12 @@
 	    });
 	}
 
-	export let data
+export let data
+
+let isCrazyGames = false;
+if (browser) {
+    isCrazyGames = OriginChecker.isCrazyGames();
+}
 
 	onMount(async () => {
 		const Sentry = await import('@sentry/capacitor'); 
@@ -33,7 +38,10 @@
 </script>
 
 <svelte:head>
-	<meta name="robots" content="noindex, nofollow" />
+        <meta name="robots" content="noindex, nofollow" />
+        {#if isCrazyGames}
+            <script src="https://sdk.crazygames.com/crazygames-sdk-v3.js"></script>
+        {/if}
 </svelte:head>
 
 {#key data.url}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -2,11 +2,8 @@
     import { onMount } from 'svelte';
     import { fade, fly } from 'svelte/transition';
 	import { PUBLIC_SENTRY_DSN } from '$lib/config';
-import { OriginChecker } from '$lib/OriginChecker';
-import { page } from '$app/stores';
-
-	
-
+	import { OriginChecker } from '$lib/OriginChecker';
+	import { page } from '$app/stores';
 	import { App } from '@capacitor/app';
 	import { browser } from '$app/environment';
 	if (browser) {
@@ -15,12 +12,8 @@ import { page } from '$app/stores';
 	    });
 	}
 
-export let data
-
-let isCrazyGames = false;
-if (browser) {
-    isCrazyGames = OriginChecker.isCrazyGames();
-}
+	export let data
+	let isCrazyGames = false;
 
 	onMount(async () => {
 		const Sentry = await import('@sentry/capacitor'); 
@@ -34,14 +27,21 @@ if (browser) {
 			replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
 			replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
 		});
+		isCrazyGames = OriginChecker.isCrazyGames();
+		if (isCrazyGames) {
+			// load the CrazyGames SDK: https://sdk.crazygames.com/crazygames-sdk-v3.js
+			const script = document.createElement('script');
+			script.src = 'https://sdk.crazygames.com/crazygames-sdk-v3.js';
+			script.onload = () => {
+				window.CrazyGames.SDK.init();
+			};
+			document.head.appendChild(script);
+		}
 	});
 </script>
 
 <svelte:head>
         <meta name="robots" content="noindex, nofollow" />
-        {#if isCrazyGames}
-            <script src="https://sdk.crazygames.com/crazygames-sdk-v3.js"></script>
-        {/if}
 </svelte:head>
 
 {#key data.url}

--- a/src/routes/(app)/intro/+page.svelte
+++ b/src/routes/(app)/intro/+page.svelte
@@ -2,9 +2,18 @@
     import { onMount } from "svelte";
     import PageContainer from "$lib/components/PageContainer.svelte";
     import { goto } from "$app/navigation";
+    import { browser } from '$app/environment';
+    import { OriginChecker } from '$lib/OriginChecker';
     import logo from '$lib/images/AppImages/ios/256.png';
 
     onMount(async () => {
+        if (browser && OriginChecker.isCrazyGames()) {
+            try {
+                await window.CrazyGames.SDK.init();
+            } catch (err) {
+                console.error('CrazyGames SDK init failed', err);
+            }
+        }
         await new Promise((resolve) => setTimeout(resolve, 2500));
         goto('/add-players', { replaceState: true });
     });


### PR DESCRIPTION
## Summary
- detect CrazyGames iframe via OriginChecker
- load CrazyGames SDK in game layout when embedded

## Testing
- `npm run validate` *(fails: svelte-check found errors)*

------
https://chatgpt.com/codex/tasks/task_e_68566d013e90832f8c539c99df4cff92